### PR TITLE
fix: set ansible tmp dir explicitly

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,4 @@
 hostfile = hosts
 interpreter_python = auto_silent
 host_key_checking = False
+remote_tmp = /tmp/.ansible-${USER}/tmp


### PR DESCRIPTION
solves permission issues on multiuser systems
