### PR TITLE
newsite ii

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 roles/.DS_Store
 host_vars/*
+group_vars/*
 group_vars/all/vars.yml
 !host_vars/example.yml
 !group_vars/all/example.yml

--- a/newcomputer.yml
+++ b/newcomputer.yml
@@ -29,7 +29,7 @@
       ansible.builtin.lineinfile:
         path: "{{ playbook_dir }}/hosts"
         line: "{{ target }}"
-        insertafter: "{{ group }}"
+        insertafter: "\\[{{ group }}\\]"
 
     - name: Add ansible user to ssh list.
       ansible.builtin.lineinfile:

--- a/newsite.yml
+++ b/newsite.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
-  connection: local 
+  connection: local
 
   vars_prompt:
     - name: app_name
-      prompt: What is your app_name? - supply full url if you know it
-      private: no
+      prompt: "Enter url of new site"
+      private: false
   tasks:
     - name: Create main yml
       template:
@@ -16,6 +16,24 @@
         src: template.nginx.conf.j2
         dest: "{{ playbook_dir }}/sites/files/{{ app_name }}.nginx.conf"
     - name: append to makefile.
-      lineinfile:
-        path: "{{ playbook_dir }}/sites/Makefile"
-        line: "{{ app_name }}:\n\tansible-playbook {{ app_name}}.yml -i ../hosts"
+      template:
+        dest: "{{ playbook_dir }}/sites/makefiles/{{ app_name }}"
+        src: Makefile.j2
+
+    - name: Add target to inventory file.
+      ansible.builtin.lineinfile:
+        path: "{{ playbook_dir }}/hosts"
+        line: "{{ app_name }}"
+        insertafter: "\\[sites\\]"
+
+    - name: Create default site vars directory if doesnt exist
+      file:
+        state: directory
+        path: "{{ playbook_dir }}/group_vars/sites"
+        force: false
+
+    - name: Create default site vars if doesnt exit
+      copy:
+        content: "ansible_user: deploy"
+        dest: "{{ playbook_dir }}/group_vars/sites/default.yml"
+        force: false

--- a/sites/Makefile
+++ b/sites/Makefile
@@ -1,5 +1,14 @@
 ANSIBLE=$$(python3 -m site --user-base)/bin/
-newsite:
+tldr:
+	@echo Available commands
+	@echo ------------------
+	@for i in `grep -v "\t" Makefile | grep "a*:" | tr -d \:`; do echo make $$i; done
+	@for i in `ls makefiles`; do echo make $$i; done
+new:
 	ansible-playbook ../newsite.yml -i ../hosts
-rhyl.io37.ch:
-	ansible-playbook rhyl.io37.ch.yml -i ../hosts
+vars:
+	@echo Available sites\:
+	@ls files | awk -F".nginx.conf" '{ print $$1 }'
+	@echo ""
+	@ansible-playbook vars.yml -i ../hosts
+include makefiles/*

--- a/sites/ansible.cfg
+++ b/sites/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+hostfile = hosts
+interpreter_python = auto_silent
+host_key_checking = False
+remote_tmp = /tmp/.ansible-${USER}/tmp

--- a/sites/makefiles/ping
+++ b/sites/makefiles/ping
@@ -1,0 +1,2 @@
+ping:
+	@echo pong

--- a/sites/vars.yml
+++ b/sites/vars.yml
@@ -1,0 +1,32 @@
+---
+- name: Setup vars
+  hosts: localhost
+  connection: local
+  vars_prompt:
+    - name: site
+      prompt: Which site are you connecting to?
+      private: false
+    - name: user
+      prompt: What is the username of the default user?
+      private: false
+      default: deploy
+
+  tasks:
+    - debug: msg="Connecting to {{ site }} as {{ user }}"
+
+    - name: Register file location
+      stat:
+        path: "files/{{ site }}.nginx.conf"
+      register: site_path
+
+    - name: Create vars folder for new target
+      file:
+        path: "../host_vars/{{ site }}"
+        state: directory
+      when: site_path.stat.exists == true
+
+    - name: Create main vars yml for target
+      copy:
+        content: "ansible_user: {{ user }}"
+        dest: "../host_vars/{{ site }}/vars.yml"
+      when: site_path.stat.exists == true

--- a/templates/Makefile.j2
+++ b/templates/Makefile.j2
@@ -1,0 +1,5 @@
+{% filter indent(width="\t") %}
+{{ app_name }}:
+if ! ansible -m ping {{ app_name }} -i ../hosts; then ansible-playbook vars.yml -i ../hosts -e "site={{ app_name }}"; fi
+ansible-playbook {{ app_name }}.yml -i ../hosts
+{% endfilter %}

--- a/templates/template.yml.j2
+++ b/templates/template.yml.j2
@@ -5,15 +5,21 @@
       command: git config --get user.email
       register: email
 
-    - debug: 
+    - debug:
         var: hostvars['localhost']['email']
-- hosts: debian
+
+- hosts: '{{ app_name }}'
+  gather_facts: false
   vars:
-    url: '{{ app_name }}' 
+    url: '{{ app_name }}'
     name: '{{ app_name }}'
     email: "{{ "{{ hostvars['localhost']['email'].stdout  }}" }}"
 
   tasks:
+    - include_vars:
+        dir: "{{ '../group_vars/sites' }}"
+      when: hostvars[inventory_hostname]['ansible_user'] is undefined
+
     - name: 'lookup subdomain ip'
       shell: nslookup {{ '{{ url }}' }} | grep Address | tail -1 | awk -F ' ' '{ print $2 }'
       register: target_ip

--- a/templates/vars/hosts.j2
+++ b/templates/vars/hosts.j2
@@ -2,4 +2,4 @@
 
 [debian]
 
-[unused]
+[sites]


### PR DESCRIPTION
- fix: add group_vars to gitignore
- fix: search for group in host file correctly
- fix: rename unused group in hosts to sites
- fix: update sites Makefile to use includes rather than filling out its own makefile
- fix: update newsite to create makefile persite and populate sites group in main inventory file
- fix: run fqdn target only on specified host, not all targets in debian group
- fix: add make vars to update site specific vars if necessary
