### PR TITLE
fix: use 'readme' design template in gh action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: cat ~/.gitconfig
 
       - name: installs the site
-        run: npm_config_yes=true npx venlo@latest --default macfair documentation
+        run: npm_config_yes=true npx venlo@latest --default macfair readme
 
       - name: copies the Docs
         run: cp -r docs/*md macfair/src/content/docs


### PR DESCRIPTION
this was renamed from documentation to readme in Venlo, and needs to change here accordingly
