### PR TITLE
cer-148: update viewpr to show branch if no pr

### DIFF
--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -106,8 +106,13 @@ closepr () {
 }
 
 viewpr () {
-  [[ $1 ]] && pr=$1 || _getpr
+  if [[ $1 ]] && [[ $1 == "b" ]]; then
+    gh browse -b $(git branch --show-current)
+    return
+  fi
+  [[ -n $1 ]] && pr=$1  || _getpr
   gh pr view $pr --web
+  [[ $? == 1 ]] && gh browse -b $(git branch --show-current)
 }
 
 delete_old_branches () {


### PR DESCRIPTION
update viewpr to show branch if no pr

- if b flag passed open branch in web instead of pr
- if no flag passed view pr as before
- if no pr exists open branch view