### PR TITLE
cer-149: custom 404 with fallback

### DIFF
--- a/files/nginx/errors.conf
+++ b/files/nginx/errors.conf
@@ -1,12 +1,15 @@
 error_page 403 /403.html;
 error_page 404 405 /404.html;
 error_page 500 501 502 503 /503.html;
+
 location = /403.html {
-  root html;
+  root $error_root;
 }
+
 location = /404.html {
-  root html;
+  root $error_root;
 }
+
 location = /503.html {
-  root html;
+  root $error_root;
 }

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -3,3 +3,4 @@
   ansible.builtin.service:
     name: nginx
     state: restarted
+  become: true

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -56,9 +56,22 @@
   become: true
   become_user: root
 
+- name: Insert map directive into nginx.conf
+  ansible.builtin.lineinfile:
+    path: /etc/nginx/nginx.conf
+    insertafter: "http {"
+    line: |
+      map $host $error_root {
+          default /usr/share/nginx/html;
+      }
+    state: present
+  notify: Restart nginx
+  become: true
+  become_user: root
+
 - name: print role name
   set_fact:
-    parent_role_name:  "{{ role_name }}"
+    parent_role_name: "{{ role_name }}"
 
 - name: add version
   include_role:


### PR DESCRIPTION
update nginx configuration for 404s

allow custom 404s with a fallback 404 by setting error_root as a variable