### PR TITLE
cer-153: siteshosts bugfix

### DIFF
--- a/newsite.yml
+++ b/newsite.yml
@@ -22,7 +22,7 @@
 
     - name: Create site/hosts file if doesnt exist
       ansible.builtin.copy:
-        content: "[sites]"
+        content: "[sites]\n"
         dest: "{{ playbook_dir }}/sites/hosts"
         force: false
 


### PR DESCRIPTION
add new line after [sites] in sites/hosts

this breaks no longer breaks when creating sites/hosts if sites/hosts doesnt exist