### PR TITLE
cer-156: add custom error root by default

### DIFF
--- a/templates/template.nginx.conf.j2
+++ b/templates/template.nginx.conf.j2
@@ -5,6 +5,7 @@ server {
       alias /var/www/html/favicon.ico;
     }
     root /var/www/html/{{ app_name }};
+    set $error_root /var/www/html/{{ app_name }};
     index index.html;
     include snippets/errors.conf;
     add_header Content-Security-Policy "\

--- a/templates/template.nginx.conf.j2
+++ b/templates/template.nginx.conf.j2
@@ -1,8 +1,14 @@
 server {
     server_name {{ app_name }};
     listen 80;
-    location = /favicon.ico {
-      alias /var/www/html/favicon.ico;
+    location / {
+      if ($request_uri ~ ^/(.*)\.md(\?|$)) {
+        return 302 /$1;
+      }
+      if ($request_uri ~ ^/docs/(.*)\.md(\?|$)) {
+        return 302 /$1;
+      }
+      try_files $uri/index.html /docs/$uri/index.html $uri $uri.html $uri/ =404;
     }
     root /var/www/html/{{ app_name }};
     set $error_root /var/www/html/{{ app_name }};

--- a/templates/template.nginx.conf.j2
+++ b/templates/template.nginx.conf.j2
@@ -7,5 +7,16 @@ server {
     root /var/www/html/{{ app_name }};
     index index.html;
     include snippets/errors.conf;
-    add_header Content-Security-Policy "font-src 'self' https://rsms.me  https://*.gstatic.com data:; frame-src 'self'; connect-src 'self' https://apis.google.com; object-src 'none'; img-src 'self' https://github.com https://*.ggpht.com https://*.googleapis.com https://*.gstatic.com data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://d3js.org https://*.googleapis.com; style-src 'self' https://rsms.me https://*.googleapis.com 'unsafe-inline';form-action 'self'; base-uri 'self';default-src 'self';frame-ancestors 'self'";
+    add_header Content-Security-Policy "\
+      font-src 'self' https://rsms.me  https://*.gstatic.com data:;\
+      frame-src 'self';\
+      connect-src 'self' https://apis.google.com;\
+      object-src 'none';\
+      img-src 'self' https://github.com https://*.githubusercontent.com https://*.ggpht.com https://*.googleapis.com https://*.gstatic.com data:;\
+      script-src 'self' 'unsafe-eval' 'unsafe-inline' https://d3js.org https://*.googleapis.com;\
+      style-src 'self' https://rsms.me https://*.googleapis.com 'unsafe-inline';\
+      form-action 'self';\
+      base-uri 'self';\
+      default-src 'self';\
+      frame-ancestors 'self'";
 }

--- a/templates/template.yml.j2
+++ b/templates/template.yml.j2
@@ -28,7 +28,6 @@
       copy:
         src: {{ app_name }}.nginx.conf
         dest: /etc/nginx/conf.d/{{ '{{ url }}' }}.conf
-        force: no
 
     - name: Creates directory
       file:


### PR DESCRIPTION
handled rewriting of md to html in conf

set nginx custom error root default

multi-line nginx security headers

too difficult to read all on one line

allow updating of nginx files

remove force no from newsite rol#e