### PR TITLE
cer-167: update viz to go to function

### DIFF
--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -62,7 +62,7 @@ m () { # Execute nearest Makefile up directory tree
 
 viz () {
   [[ ! $1 ]] && vi ~/.zsh/_trialling.zsh && return
-  local result=$(grep -n "^$1.*{" ~/.zsh/*.zsh)
+  local result=$(grep -n "^$1[[:space:]]*()[[:space:]]*{" ~/.zsh/*.zsh)
   local func=$(echo "$result" | awk -F':' '{print $1}')
   local line=$(echo "$result" | awk -F':' '{print $2}')
   [[ ! $func ]] && vi ~/.zsh/_trialling.zsh && return

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -61,8 +61,13 @@ m () { # Execute nearest Makefile up directory tree
 }
 
 viz () {
-  [[ -n $1 ]] && a=$1.zsh || a=_trialling.zsh
-  vi ~/.zsh/$a
+  [[ ! $1 ]] && vi ~/.zsh/_trialling.zsh && return
+  local result=$(grep -n "^$1.*{" ~/.zsh/*.zsh)
+  local func=$(echo "$result" | awk -F':' '{print $1}')
+  local line=$(echo "$result" | awk -F':' '{print $2}')
+  [[ ! $func ]] && vi ~/.zsh/_trialling.zsh && return
+  echo "$(ColorGreen $1) found in $(ColorCyan $func)"
+  vi +$line $func
 }
 
 cdrepo () {


### PR DESCRIPTION
search for functions more accurately

grep for any number of spaces followed by () followed by any number of spaces followed by {

update viz to go straight to function

- instead of just opening correct zsh file, go right to where it exists in that file
- edit trialling file if no argument passed
- edit trialling file if function not found