### PR TITLE
cer-244: improve command_not_found_handler

### DIFF
--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -2,7 +2,7 @@ export MARKPATH=$HOME/.marks
 alias sedi='sed -i "" -e'
 
 command_not_found_handler () {
-  if [ -f Makefile ] && grep "^$1:" Makefile > /dev/null; then
+  if [ -f Makefile ] && grep -q "^$1:" Makefile; then
     local rule=$(echo $1 | awk -F ":" '{print $1}')
     make $rule
     return 0

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -7,6 +7,10 @@ command_not_found_handler () {
     make $rule
     return 0
   fi
+  if [[ -f package.json ]] && jq .scripts package.json | grep -q "\"$1\":"; then
+    npm run $1
+    return 0
+  fi
   echo "zsh: command not found: $1"
   return 127  # Return an exit status indicating command not found
 }


### PR DESCRIPTION
use grep -q instead of pipe dev null

- improve syntax in command not found handler

update command not found handler

- look inside package.json in addition to Makefile