### PR TITLE
cer-281: update git unpark and unparkall

### DIFF
--- a/templates/gitconfig.j2
+++ b/templates/gitconfig.j2
@@ -22,6 +22,7 @@
         full = ! git branch --format='%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:reset)' --color=always | column -ts'|'
         park = ! git add . && git commit -m \"wip: parking this here for now\"
         unparkall = !git reset  $(git rev-parse main)
+        unpark = !git reset $(git rev-list --invert-grep --grep='^wip:' -n 1 HEAD)
         last = show HEAD
 [push]
         autoSetupRemote = true

--- a/templates/gitconfig.j2
+++ b/templates/gitconfig.j2
@@ -21,7 +21,7 @@
         branches = ! git branch --no-merge main --format='%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:reset)' --color=always | column -ts'|' | head -n 10
         full = ! git branch --format='%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:reset)' --color=always | column -ts'|'
         park = ! git add . && git commit -m \"wip: parking this here for now\"
-        unpark = !git reset  $(git rev-parse main)
+        unparkall = !git reset  $(git rev-parse main)
         last = show HEAD
 [push]
         autoSetupRemote = true


### PR DESCRIPTION
add new version of unpark

- unoark now just goes back to the last non-wip commit not all the way back to main

rename git unpark to unparkall