### PR TITLE
dont reclone ohmyzsh

### DIFF
--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -1,8 +1,9 @@
 ---
 - name: Cloning oh-my-zsh
   git:
-    repo=https://github.com/robbyrussell/oh-my-zsh
-    dest=~{{ macbook_user.stdout }}/.oh-my-zsh
+    repo: https://github.com/ohmyzsh/ohmyzsh
+    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh
+    update: no
 
 - name: Copy zsh theme
   copy:

--- a/roles/terminal/tasks/debian.yml
+++ b/roles/terminal/tasks/debian.yml
@@ -8,8 +8,9 @@
 
 - name: Cloning oh-my-zsh
   git:
-    repo=https://github.com/robbyrussell/oh-my-zsh
-    dest=~{{ macbook_user.stdout }}/.oh-my-zsh
+    repo: https://github.com/ohmyzsh/ohmyzsh
+    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh
+    update: no
 
 - name: Copy zsh theme
   copy:


### PR DESCRIPTION
dont attempt to reclone ohmyzsh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated oh-my-zsh installation to use the official repository source
  * Disabled automatic updates to prevent unexpected changes during terminal configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->