### PR TITLE
install claude

### DIFF
--- a/files/zsh/paths.zsh
+++ b/files/zsh/paths.zsh
@@ -1,3 +1,4 @@
 export PATH="/usr/local/sbin:$PATH"
 export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
 export PATH="$HOME/.pyvenv-ansible/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -25,30 +25,36 @@
     dest: ~{{ macbook_user.stdout }}/.gemini/GEMINI.md
 
 - name: Get list of installed MCP servers
-  ansible.builtin.shell: npx @anthropic-ai/claude-code mcp list 2>/dev/null || echo ""
+  ansible.builtin.shell: claude mcp list 2>/dev/null || echo ""
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
   register: mcp_list
   changed_when: false
 
 - name: Add Prisma MCP server
-  ansible.builtin.shell: npx @anthropic-ai/claude-code mcp add -s user prisma -- npx prisma mcp
-  register: prisma_mcp
+  ansible.builtin.shell: claude mcp add -s user prisma -- npx prisma mcp
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
   when: "'prisma' not in mcp_list.stdout"
   ignore_errors: true
 
 - name: Add Semgrep MCP server
-  ansible.builtin.shell: npx @anthropic-ai/claude-code mcp add -s user semgrep -- semgrep mcp
-  register: semgrep_mcp
+  ansible.builtin.shell: claude mcp add -s user semgrep -- semgrep mcp
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
   when: "'semgrep' not in mcp_list.stdout"
   ignore_errors: true
 
 - name: Add Sentry MCP server
-  ansible.builtin.shell: npx @anthropic-ai/claude-code mcp add -s user --transport http sentry https://mcp.sentry.dev/mcp
-  register: sentry_mcp
+  ansible.builtin.shell: claude mcp add -s user --transport http sentry https://mcp.sentry.dev/mcp
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
   when: "'sentry' not in mcp_list.stdout"
   ignore_errors: true
 
 - name: Add Linear MCP server
-  ansible.builtin.shell: npx @anthropic-ai/claude-code mcp add -s user linear --transport sse https://mcp.linear.app/sse
-  register: linear_mcp
+  ansible.builtin.shell: claude mcp add -s user linear --transport sse https://mcp.linear.app/sse
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
   when: "'linear' not in mcp_list.stdout"
   ignore_errors: true

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -122,6 +122,15 @@
     - "passlib"
     - "yq"
 
+- name: Check if Claude Code is installed
+  stat:
+    path: "~{{ macbook_user.stdout }}/.local/bin/claude"
+  register: claude_installed
+
+- name: Install Claude Code
+  shell: curl -fsSL https://claude.ai/install.sh | bash
+  when: not claude_installed.stat.exists
+
 - name: link node
   shell: /opt/homebrew/bin/brew link --overwrite node@{{ node_version }}
 


### PR DESCRIPTION
install claude natively instead of using npx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prepended $HOME/.local/bin to the command search path to surface locally installed tools.
  * Updated Claude Code CLI integrations for smoother local command usage.
  * Added conditional automatic installation of Claude Code on macOS when not present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->