### PR TITLE
claudev

### DIFF
--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "alwaysThinkingEnabled": true,
+  "enabledPlugins": {
+    "voicemode@mbailey": true
+  },
+  "permissions": {
+    "allow": [
+      "mcp__voicemode__*",
+      "mcp__plugin_voicemode_voicemode__*"
+    ],
+    "deny": []
+  }
+}

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -538,6 +538,8 @@ claudewright () {
 }
 
 alias claudep='claude --permission-mode plan'
+alias claudev='claude --append-system-prompt "Always respond using the mcp__voicemode__converse tool to speak your responses aloud."'
+alias claudevp='claude --permission-mode plan --append-system-prompt "Always respond using the mcp__voicemode__converse tool to speak your responses aloud."'
 
 vpn () { # Toggle wireguard VPN # ➜ vpn up
   local config=${2:-vps}

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -9,6 +9,11 @@
     src: claude/config.md
     dest: ~{{ macbook_user.stdout }}/.claude/CLAUDE.md
 
+- name: Copy Claude settings
+  copy:
+    src: claude/settings.json
+    dest: ~{{ macbook_user.stdout }}/.claude/settings.json
+
 - name: Copy Claude skills
   copy:
     src: claude/skills/


### PR DESCRIPTION
allow claude voicemode by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice mode support integrated into Claude for audio-based interactions
  * New command aliases enable quick access to voice conversation modes
  * Voice mode is automatically enabled and configured during system setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->