### PR TITLE
claude doctor hook

### DIFF
--- a/files/claude/config.md
+++ b/files/claude/config.md
@@ -1,7 +1,15 @@
+# Claude Configuration
+
+All Claude config lives in `~/macfair/files/claude/`:
+- `config.md` → `~/.claude/CLAUDE.md`
+- `settings.json` → `~/.claude/settings.json`
+- `hooks/`, `commands/`, `skills/` → `~/.claude/`
+
+Never edit `~/.claude/` directly. Edit macfair, then tell user to run `make claude`.
+
 # General
 
 - Prefer idempotent operations - safe to run multiple times with same result
-- Do not edit ~/.claude/CLAUDE.md directly - edit ~/macfair/files/claude/config.md instead
 - Prefer proper fixes over quick fixes - investigate root causes rather than masking symptoms
 - When presenting multiple options, grade each A-F with score out of 100, weighted towards proper professional solutions
 - Be terse, not flowery

--- a/files/claude/hooks/doctor.ts
+++ b/files/claude/hooks/doctor.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env bun
+// SessionStart hook: Daily check for package updates
+// Runs once per day, notifies about new versions of watched packages
+
+import { dirname, join } from 'path'
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { homedir } from 'os'
+
+const WATCHED_PACKAGES = ['next', 'react', 'prisma']
+
+interface PackageInfo {
+  version: string
+  released: string
+}
+
+interface State {
+  lastChecked: string
+  notified: Record<string, PackageInfo>
+}
+
+function getTodayDate(): string {
+  const tz = process.env.TIME_ZONE || Intl.DateTimeFormat().resolvedOptions().timeZone
+  const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' })
+  return formatter.format(new Date())
+}
+
+function getStateFile(): string {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || homedir()
+  return join(homeDir, '.claude', 'MEMORY', 'State', 'doctor.json')
+}
+
+function loadState(): State {
+  try {
+    const stateFile = getStateFile()
+    if (existsSync(stateFile)) {
+      return JSON.parse(readFileSync(stateFile, 'utf-8'))
+    }
+  } catch {}
+  return { lastChecked: '', notified: {} }
+}
+
+function saveState(state: State): void {
+  try {
+    const stateFile = getStateFile()
+    const dir = dirname(stateFile)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    writeFileSync(stateFile, JSON.stringify(state, null, 2) + '\n')
+  } catch {}
+}
+
+function formatShortOrdinalWithYear(date: Date): string {
+  const day = date.getUTCDate()
+  const suffix = [11, 12, 13].includes(day % 100) ? 'th'
+    : day % 10 === 1 ? 'st'
+    : day % 10 === 2 ? 'nd'
+    : day % 10 === 3 ? 'rd' : 'th'
+  const month = date.toLocaleString('en-GB', { month: 'short', timeZone: 'UTC' })
+  const year = date.getUTCFullYear()
+  return `${day}${suffix} ${month} ${year}`
+}
+
+async function getLatestVersion(pkg: string): Promise<PackageInfo | null> {
+  try {
+    const proc = Bun.spawn(['npm', 'view', pkg, 'version', 'time', '--json'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const output = await new Response(proc.stdout).text()
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return null
+    const data = JSON.parse(output)
+    const version = data.version
+    const releaseDate = data.time?.[version]
+    if (!version || !releaseDate) return null
+    const released = formatShortOrdinalWithYear(new Date(releaseDate))
+    return { version, released }
+  } catch {
+    return null
+  }
+}
+
+async function main() {
+  if (process.env.CLAUDE_CODE_AGENT || process.env.SUBAGENT === 'true') {
+    process.exit(0)
+  }
+
+  const today = getTodayDate()
+  const state = loadState()
+
+  if (state.lastChecked === today) {
+    process.exit(0)
+  }
+
+  const results = await Promise.all(
+    WATCHED_PACKAGES.map(pkg => getLatestVersion(pkg).then(info => ({ pkg, info })))
+  )
+
+  const updates: string[] = []
+  for (const { pkg, info } of results) {
+    if (!info) continue
+    const lastNotified = state.notified[pkg]
+    if (info.version !== lastNotified?.version) {
+      updates.push(`${pkg} ${info.version} ${info.released}`)
+      state.notified[pkg] = info
+    }
+  }
+
+  state.lastChecked = today
+  saveState(state)
+
+  if (updates.length > 0) {
+    console.log(`Doctor: ${updates.join(', ')}`)
+  }
+
+  process.exit(0)
+}
+
+main()

--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -23,6 +23,10 @@
           {
             "type": "command",
             "command": "bun run ~/.claude/hooks/celeste.ts"
+          },
+          {
+            "type": "command",
+            "command": "bun run ~/.claude/hooks/doctor.ts"
           }
         ]
       }

--- a/files/claude/skills/doctor/SKILL.md
+++ b/files/claude/skills/doctor/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: doctor
+description: Check latest package versions from the daily doctor check. Use when asking about updates, versions, or package news.
+---
+
+# Doctor
+
+Show the user what package updates have been detected.
+
+## Instructions
+
+1. Read `~/.claude/MEMORY/State/doctor.json`
+2. Report the versions with release dates:
+   - next: 16.1.1 10th Jan 2026
+   - react: 19.2.3 8th Jan 2026
+   - prisma: 7.2.0 5th Jan 2026
+3. Include when it was last checked
+
+Keep it brief. No extra commentary unless asked.

--- a/files/git/ignore
+++ b/files/git/ignore
@@ -28,7 +28,6 @@ cdk.context.json
 # Logs and databases #
 ######################
 *.log
-*.sql
 *.sqlite
 
 # OS generated files #


### PR DESCRIPTION
add doctor hook for daily package version checks

Checks npm versions for next, react, prisma on session start.
Notifies once per day when new versions are detected.
Don't add sql files to git ignore, prisma needs the migrations under version control

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily package version monitoring that tracks updates for key dependencies and reports them at session start.

* **Documentation**
  * Updated configuration guidance to clarify the proper workflow for editing Claude settings.

* **Chores**
  * Updated git ignore configuration to track SQL files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->