### PR TITLE
get shit done

### DIFF
--- a/files/claude/commands/commit.md
+++ b/files/claude/commands/commit.md
@@ -36,15 +36,22 @@
 5. **Commit message format:**
    - **Prefix:** `feat:` or `fix:` (semantic versioning)
    - **Head:** Concise, picks most relevant change if multiple things
-   - **Body:** Only if necessary (multiple things, or needs more detail)
+   - **Body:** Flat list of bullet points, one per change
+     - Each line self-contained (no grouped sections with headers)
+     - Order by importance (most significant changes first)
+     - No parenthetical asides — either say it or don't
+     - Skip body if only one trivial change
    - **Never** attribute code to Claude
 
 6. **Example (amending existing commit):**
    ```bash
    git commit --amend --reset-author -m "$(cat <<'EOF'
-   feat: add user authentication with JWT
+   feat: add user authentication and session management
 
-   Implements login/logout endpoints and token validation middleware.
+   - Add JWT token validation middleware
+   - Implement login/logout API endpoints
+   - Add session expiry handling
+   - Fix password hashing for special characters
    EOF
    )"
    ```

--- a/files/claude/config.md
+++ b/files/claude/config.md
@@ -60,6 +60,12 @@ Never edit `~/.claude/` directly. Edit macfair, then tell user to run `make clau
 
 - No semicolons
 - Strict mode, avoid `any`
+- Prefer inferred/existing types over manual definitions:
+  - `typeof data[number]` for array item types from queries
+  - Prisma/Drizzle generated types (`User`, `Upload`)
+  - `z.infer<typeof schema>` for Zod schemas
+  - tRPC `RouterOutputs['router']['procedure']` for endpoint return types
+  - Only define types when no source of truth exists
 - Use barrel exports (index files) for clean imports
 - Use `@/` path alias instead of relative imports
 - Import from specific subdirectories, not root barrel (e.g., `@/components/skeletons` not `@/components`)

--- a/files/claude/hooks/security-validator.ts
+++ b/files/claude/hooks/security-validator.ts
@@ -79,10 +79,18 @@ const ATTACK_PATTERNS = {
     message: 'WARNING: Environment/credential access detected'
   },
 
-  // Tier 6: Git dangerous operations - Warn
+  // Tier 6: Git push - Block (commit only, user pushes)
+  gitPush: {
+    patterns: [
+      /git\s+push/i,                               // Any git push
+    ],
+    action: 'block',
+    message: 'BLOCKED: git push not allowed - commit only, user pushes'
+  },
+
+  // Tier 7: Git dangerous operations - Warn
   gitDangerous: {
     patterns: [
-      /git\s+push.*(-f|--force)/i,                 // Force push
       /git\s+reset\s+--hard/i,                     // Hard reset
       /git\s+clean\s+-fd/i,                        // Clean untracked
       /git\s+checkout\s+--\s+\./i,                 // Discard all changes

--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -11,7 +11,13 @@
   "permissions": {
     "allow": [
       "mcp__voicemode__*",
-      "mcp__plugin_voicemode_voicemode__*"
+      "mcp__plugin_voicemode_voicemode__*",
+      "WebFetch(domain:*)",
+      "WebSearch",
+      "Read(*)",
+      "Glob(*)",
+      "Grep(*)",
+      "Skill(skill:review-pr)"
     ],
     "deny": [
       "Read(**/.env)",

--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -55,11 +55,11 @@ if command -v jq &> /dev/null && [ -n "$input" ]; then
 
         # Color based on absolute token thresholds (scaled to 155K compaction limit)
         # Green: <40%, Yellow: <60%, Orange: <90%, Red: >=90% (compaction imminent)
-        if [ "$TOTAL_TOKENS" -le 62000 ]; then
+        if [ "$TOTAL_TOKENS" -le 60000 ]; then
             BAR_COLOR="$GREEN"
-        elif [ "$TOTAL_TOKENS" -le 93000 ]; then
+        elif [ "$TOTAL_TOKENS" -le 95000 ]; then
             BAR_COLOR="$YELLOW"
-        elif [ "$TOTAL_TOKENS" -le 139500 ]; then
+        elif [ "$TOTAL_TOKENS" -le 140000 ]; then
             BAR_COLOR="$ORANGE"
         else
             BAR_COLOR="$RED"

--- a/files/git/ignore
+++ b/files/git/ignore
@@ -82,3 +82,5 @@ CLAUDE.md
 .claude
 .cursorrules
 .terminal-profile
+.planning
+tmp

--- a/files/git/post-checkout
+++ b/files/git/post-checkout
@@ -12,3 +12,5 @@ else
     echo "⚠️  Failed to fetch from origin/$default_branch (behind count may be stale)" >&2
   fi
 fi
+
+exit 0

--- a/files/pnpm-audit/daily-pnpm-audit.sh
+++ b/files/pnpm-audit/daily-pnpm-audit.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+set -e
+
+# Required env vars
+PROJECT_DIR="${AUDIT_PROJECT_DIR:?AUDIT_PROJECT_DIR not set}"
+SLACK_WEBHOOK="${AUDIT_SLACK_WEBHOOK:?AUDIT_SLACK_WEBHOOK not set}"
+
+# Ensure PATH includes homebrew and node binaries for cron/launchd environment
+NVM_BIN=""
+if [[ -d "$HOME/.nvm/versions/node" ]]; then
+  NVM_NODE=$(ls "$HOME/.nvm/versions/node" 2>/dev/null | tail -1)
+  [[ -n "$NVM_NODE" ]] && NVM_BIN="$HOME/.nvm/versions/node/$NVM_NODE/bin:"
+fi
+export PATH="/opt/homebrew/bin:/usr/local/bin:${NVM_BIN}$PATH"
+
+LOG_FILE="$PROJECT_DIR/tmp/audit-$(date +%Y%m%d).log"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+send_notification() {
+  local subject="$1"
+  local body="$2"
+  log "Sending notification: $subject"
+  jq -n --arg subject "*$subject*" --arg body "$body" '{text: "\($subject)\n\($body)"}' | \
+    curl -s -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK" > /dev/null
+}
+
+cd "$PROJECT_DIR"
+source .env 2>/dev/null || true
+mkdir -p "$PROJECT_DIR/tmp"
+
+log "Starting daily audit"
+
+# Ensure we're on main and up to date
+git checkout main 2>/dev/null || true
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  log "ERROR: Could not checkout main (on $CURRENT_BRANCH). Aborting."
+  exit 1
+fi
+git pull origin main || log "Warning: git pull failed, running audit on local copy"
+pnpm install --silent 2>/dev/null || true
+
+# Create safety branch
+BRANCH_NAME="audit-$(date +%Y%m%d-%H%M%S)"
+git checkout -b "$BRANCH_NAME"
+log "On safety branch: $BRANCH_NAME"
+
+# Part 1: Check for new vulnerabilities
+log "Running pnpm audit..."
+set +e
+AUDIT_OUTPUT=$(pnpm audit 2>&1)
+AUDIT_EXIT=$?
+set -e
+
+NEW_VULNS=""
+if [[ $AUDIT_EXIT -ne 0 ]]; then
+  NEW_VULNS=$(echo "$AUDIT_OUTPUT" | grep -E "│ (Package|Severity|Vulnerable)" | head -20)
+  log "New vulnerabilities found"
+else
+  log "No new vulnerabilities"
+fi
+
+# Part 2: Check if existing overrides are still needed
+OVERRIDES=$(jq -r '.pnpm.overrides // {} | keys[]' package.json 2>/dev/null)
+OVERRIDE_REPORT=""
+
+if [[ -n "$OVERRIDES" ]]; then
+  log "Testing if overrides are still needed..."
+
+  # Save original package.json
+  cp package.json package.json.backup
+
+  while IFS= read -r pkg; do
+    [[ -z "$pkg" ]] && continue
+    log "Testing override: $pkg"
+
+    # Remove this specific override
+    jq --arg pkg "$pkg" 'del(.pnpm.overrides[$pkg])' package.json > package.json.tmp
+    mv package.json.tmp package.json
+
+    # Clean install and audit
+    rm -rf node_modules pnpm-lock.yaml 2>/dev/null || true
+    if ! pnpm install --silent 2>/dev/null; then
+      log "Install failed for $pkg, marking as still needed"
+      OVERRIDE_REPORT="$OVERRIDE_REPORT\n⚠️ $pkg - install failed, skipped"
+    elif pnpm audit > /dev/null 2>&1; then
+      log "Override '$pkg' is NO LONGER NEEDED"
+      OVERRIDE_REPORT="$OVERRIDE_REPORT\n✅ $pkg - can be removed"
+    else
+      log "Override '$pkg' is still needed"
+      OVERRIDE_REPORT="$OVERRIDE_REPORT\n🔒 $pkg - still needed"
+    fi
+
+    # Restore for next iteration
+    cp package.json.backup package.json
+  done <<< "$OVERRIDES"
+
+  # Restore original
+  mv package.json.backup package.json
+fi
+
+# Return to main
+log "Returning to main branch"
+if git checkout main 2>/dev/null; then
+  git branch -D "$BRANCH_NAME" 2>/dev/null || true
+  pnpm install --silent 2>/dev/null || true
+else
+  log "WARNING: Could not return to main, staying on $BRANCH_NAME"
+fi
+
+# Build consolidated message
+MESSAGE=""
+
+if [[ -n "$NEW_VULNS" ]]; then
+  MESSAGE="*New Vulnerabilities:*\n\`\`\`$NEW_VULNS\`\`\`"
+else
+  MESSAGE="*New Vulnerabilities:* None"
+fi
+
+if [[ -n "$OVERRIDE_REPORT" ]]; then
+  MESSAGE="$MESSAGE\n\n*Override Status:*$OVERRIDE_REPORT"
+elif [[ -z "$OVERRIDES" ]]; then
+  MESSAGE="$MESSAGE\n\n*Overrides:* None configured"
+fi
+
+# Send single notification
+if [[ -n "$NEW_VULNS" ]] || echo "$OVERRIDE_REPORT" | grep -q "can be removed"; then
+  send_notification "🚨 Audit: Action Needed" "$MESSAGE"
+else
+  send_notification "✅ Audit: All Clear" "$MESSAGE"
+fi
+
+log "Daily audit complete"

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -27,9 +27,9 @@ _claude_unlock() {
 _claude_run() {
   _claude_lock || return 1
   command claude "$@"
-  local status=$?
+  local ret=$?
   _claude_unlock
-  return $status
+  return $ret
 }
 
 claude() { _claude_run "$@"; }

--- a/files/zsh/gsd.zsh
+++ b/files/zsh/gsd.zsh
@@ -1,0 +1,98 @@
+# GSD (Get Shit Done) convenience wrappers
+# Usage: gsd <command> [args]
+
+# Reclaim from git-svn plugin
+unalias gsd 2>/dev/null
+
+gsd() {
+  local cmd="${1:-help}"
+  shift 2>/dev/null
+
+  case "$cmd" in
+    help|--help|-h)
+      cat <<'EOF'
+Usage: gsd <command> [args]
+
+Commands:
+  new             Start new project (/gsd:new-project)
+  milestone [n]   Start new milestone (/gsd:new-milestone [name])
+  map [area]      Map existing codebase (/gsd:map-codebase [area])
+  discuss [N]     Discuss a phase (/gsd:discuss-phase N)
+  plan [N]        Plan a phase (/gsd:plan-phase N)
+  exec [N]        Execute a phase (/gsd:execute-phase N)
+  verify [N]      Verify work (/gsd:verify-work N)
+  resume          Resume work (/gsd:resume-work)
+  pause           Pause work (/gsd:pause-work)
+  progress        Check progress (/gsd:progress)
+  add [desc]      Add a todo (/gsd:add-todo [desc])
+  todos           Check todos (/gsd:check-todos)
+  debug [desc]    Debug an issue (/gsd:debug [desc])
+EOF
+      ;;
+
+    new)
+      claude "/gsd:new-project"
+      ;;
+
+    milestone)
+      claude "/gsd:new-milestone $*"
+      ;;
+
+    map)
+      claude "/gsd:map-codebase $*"
+      ;;
+
+    discuss)
+      claude "/gsd:discuss-phase $*"
+      ;;
+
+    plan)
+      claude "/gsd:plan-phase $*"
+      ;;
+
+    exec|execute)
+      claude "/gsd:execute-phase $*"
+      ;;
+
+    verify)
+      claude "/gsd:verify-work $*"
+      ;;
+
+    resume)
+      claude "/gsd:resume-work"
+      ;;
+
+    pause)
+      claude "/gsd:pause-work"
+      ;;
+
+    progress|status)
+      claude "/gsd:progress"
+      ;;
+
+    add)
+      claude "/gsd:add-todo $*"
+      ;;
+
+    todos)
+      claude "/gsd:check-todos"
+      ;;
+
+    debug)
+      claude "/gsd:debug $*"
+      ;;
+
+    *)
+      echo "Unknown command: $cmd"
+      echo "Run 'gsd help' for usage."
+      return 1
+      ;;
+  esac
+}
+
+# Completion
+_gsd() {
+  local commands="new milestone map discuss plan exec verify resume pause progress add todos debug help"
+  _arguments "1:command:($commands)"
+}
+compdef _gsd gsd 2>/dev/null

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -457,10 +457,6 @@ venv () {
   [ $1 ] && vi .env.$1 || vi .env
 }
 
-treeg () { # tree with grep filter # ➜ treeg node_modules
-  tree . | grep $1
-}
-
 vpn () { # Toggle wireguard VPN # ➜ vpn up
   local config=${2:-vps}
   [[ $1 = "up" || $1 = "down" ]] && sudo wg-quick $1 $config
@@ -507,4 +503,24 @@ makefile () { # List or copy makefile templates # ➜ makefile git
   mkdir -p makefiles
   cp "$_dir/$1.mk" makefiles/
   echo "Copied $1.mk to makefiles/"
+}
+
+catn () { # cat with line numbers, optionally starting at line N # ➜ catn file.ts 42
+  cat -n "$1" | tail -n +${2:-1}
+}
+
+vimn () { # Open vim at specific line # ➜ vimn file.ts 42
+  vi +${2:-1} "$1"
+}
+
+treeg () { # Tree, optionally filtered by grep # ➜ treeg component
+  if [[ -z $1 ]]; then
+    tree .
+  else
+    tree . | grep -- "$1"
+  fi
+}
+
+treel () { # Tree with depth limit # ➜ treel 2
+  tree -L ${1:-2}
 }

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -77,6 +77,13 @@
   when: "'semgrep' not in mcp_list.stdout"
   ignore_errors: true
 
+- name: Add Playwright MCP server
+  ansible.builtin.shell: claude mcp add -s user playwright -- npx @playwright/mcp@latest
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
+  when: "'playwright' not in mcp_list.stdout"
+  ignore_errors: true
+
 - name: Add voicemode marketplace
   ansible.builtin.shell: claude plugin marketplace add https://github.com/mbailey/claude-plugins
   environment:
@@ -186,3 +193,8 @@
     src: karabiner/karabiner.json
     dest: "{{ ansible_env.HOME }}/.config/karabiner/karabiner.json"
     force: no
+
+- name: Install/update GSD (always runs for latest)
+  ansible.builtin.command: npx get-shit-done-cc@latest --global
+  environment:
+    PATH: "/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -96,6 +96,7 @@
     - "rar"
     - "karabiner-elements"
     - "opensuperwhisper"
+    - "steipete/tap/repobar"
 
 - name: Copy zshenv
   copy:

--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -36,3 +36,15 @@
     src: iterm.json.j2
     dest: ~{{ macbook_user.stdout }}/Library/Application Support/iTerm2/DynamicProfiles/iterm.json
   when: iterm_path.stat.exists
+
+- name: Create pnpm-audit directory
+  file:
+    path: "{{ ansible_env.HOME }}/work/crons/pnpm-audit"
+    state: directory
+    mode: "0755"
+
+- name: Copy pnpm-audit script
+  copy:
+    src: pnpm-audit/daily-pnpm-audit.sh
+    dest: "{{ ansible_env.HOME }}/work/crons/pnpm-audit/daily-pnpm-audit.sh"
+    mode: "0755"


### PR DESCRIPTION
add GSD workflow, Playwright MCP, and shell improvements

- Add Playwright MCP server globally
- Block git push in security-validator
- Add gsd.zsh with Get Shit Done workflow commands
- Install GSD via npx in claude.yml
- Add TypeScript type inference guidance to config.md
- Add catn, vimn, treeg, treel shell utilities
- Add pnpm-audit daily cron job
- Add repobar brew cask
- Fix post-checkout hook exit code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New shell helpers and a GSD CLI with autocompletion.
  * Daily PNPM audit workflow with Slack notifications and override checks.
  * Playwright install support in setup tooling.

* **Improvements**
  * Commit guidance now requires a flat, ordered bullet-body format.
  * Typing guidance prefers inferred/existing types.
  * Expanded runtime permissions and adjusted status-line thresholds.
  * Stronger git-push blocking behavior in security checks.

* **Chores**
  * Added .planning and tmp to ignore list; post-checkout now exits successfully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->