### PR TITLE
gco

### DIFF
--- a/files/git/post-checkout
+++ b/files/git/post-checkout
@@ -1,16 +1,6 @@
-current_branch=$(git rev-parse --abbrev-ref HEAD)
-default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-default_branch=${default_branch:-main}
-
-if [ "$current_branch" = "$default_branch" ]; then
-  git pull origin "$default_branch"
-else
-  if git fetch origin "$default_branch" -q 2>/dev/null; then
-    behind=$(git rev-list --count HEAD..origin/"$default_branch" 2>/dev/null)
-    [[ "${behind:-0}" -gt 0 ]] && echo "⚠️  $behind commits behind $default_branch"
-  else
-    echo "⚠️  Failed to fetch from origin/$default_branch (behind count may be stale)" >&2
-  fi
-fi
-
-exit 0
+#!/bin/zsh
+GIT_HOOK=1
+source ~/.zsh/colors.zsh
+source ~/.zsh/git.zsh
+source ~/.zsh/welcome.zsh
+_git_sync

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -34,6 +34,9 @@ _git_sync() {
   if [[ "${behind:-0}" -gt 0 ]]; then
     [[ "$fetch_failed" = true ]] && echo "⚠️  $behind commits behind $default (stale)" || echo "⚠️  $behind commits behind $default"
   fi
+
+  [[ -n "$GIT_HOOK" ]] && _tab_untracked || _tab_uncommitted
+  _tab_commits
 }
 
 repos () { # List all repos # ➜ repos public

--- a/files/zsh/welcome.zsh
+++ b/files/zsh/welcome.zsh
@@ -131,14 +131,19 @@ dashboard() {
   echo ""
 }
 
-_tab_uncommitted() {
+_tab_git_files() {
+  local filter="$1" label="$2"
   local files=$(git status --short 2>/dev/null)
+  [[ -n "$filter" ]] && files=$(echo "$files" | grep "$filter")
   [[ -z "$files" ]] && return
 
   local count=$(echo "$files" | wc -l | tr -d ' ')
-  echo -e "\e[32m${count} files uncommitted\e[0m"
+  echo -e "\e[33m${count} ${label}\e[0m"
   echo "$files"
 }
+
+_tab_uncommitted() { _tab_git_files "" "files uncommitted"; }
+_tab_untracked() { _tab_git_files '^??' "untracked"; }
 
 _tab_commits() {
   local default=$(_default_branch 2>/dev/null)
@@ -168,14 +173,14 @@ _tab_todos() {
 }
 
 tabin() {
-  [[ -f .terminal-profile ]] && cpr "$(cat .terminal-profile)"
+  [[ -f .terminal-profile ]] && type cpr &>/dev/null && cpr "$(cat .terminal-profile)"
   _tab_uncommitted
   _tab_commits
   _tab_todos
 }
 
-# Auto-run on new iTerm sessions
-if [[ -n "$ITERM_SESSION_ID" ]]; then
+# Auto-run on new iTerm sessions (skip if sourced from git hook)
+if [[ -z "$GIT_HOOK" && -n "$ITERM_SESSION_ID" ]]; then
   if _is_new_window; then
     dashboard
   elif [[ -d .git ]]; then


### PR DESCRIPTION
add status display to git checkout and cd

consolidate gco behaviour, cd behaviour, and new tab behavior around git status display stuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Git checkout operation now uses a centralized sync function for streamlined behavior.

* **Improvements**
  * Terminal status display now distinguishes between untracked and uncommitted files based on context.
  * Updated visual styling for file count indicators in terminal tabs.
  * Refined terminal profile initialization conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->