### PR TITLE
dashboard3

### DIFF
--- a/files/zsh/db.zsh
+++ b/files/zsh/db.zsh
@@ -12,7 +12,13 @@ _userexists() {
 
 dblist () { # List all PostgreSQL databases # ➜ dblist [filter]
   local result=$(psql -d postgres -tc "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY oid DESC")
-  [[ -n "$1" ]] && echo "$result" | grep -i "$1" || echo "$result"
+  if [[ -n "$1" ]]; then
+    echo "$result" | grep -i "$1"
+  else
+    local total=$(echo "$result" | wc -l | tr -d ' ')
+    echo "$result" | head -20
+    (( total > 20 )) && echo "\ntotal \e[34m$total\e[0m"
+  fi
 }
 
 dbconnect () { # Connect to a database # ➜ dbconnect myapp

--- a/files/zsh/gsd.zsh
+++ b/files/zsh/gsd.zsh
@@ -3,6 +3,7 @@
 
 # Reclaim from git-svn plugin
 unalias gsd 2>/dev/null
+alias projects=gsd
 
 HUBS_DIR="$HOME/.claude/hubs"
 HUBS_REGISTRY="$HUBS_DIR/registry.json"

--- a/files/zsh/welcome.zsh
+++ b/files/zsh/welcome.zsh
@@ -61,7 +61,7 @@ _dashboard_hubs() {
 _dashboard_gsd() {
   local output=$(gsds 2>/dev/null)
   [[ -z "$output" || "$output" == *"No GSD projects"* || "$output" == *"No projects"* ]] && return
-  _dashboard_header "GSD Projects" "" "gsd"
+  _dashboard_header "Projects" "" "projects"
   echo "$output"
 }
 
@@ -145,6 +145,7 @@ tabin() {
 # Auto-run on new iTerm sessions (skip if sourced from git hook)
 if [[ -z "$GIT_HOOK" && -n "$ITERM_SESSION_ID" ]]; then
   if _is_new_window; then
+    return  # remove to auto-run dashboard
     dashboard
   elif [[ -d .git ]]; then
     tabin


### PR DESCRIPTION
rename GSD to Projects and disable auto-dashboard

- Add 'projects' alias for gsd command
- Rename dashboard header from "GSD Projects" to "Projects"
- Disable auto-run dashboard on new iTerm sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `projects` command as a convenient shorthand.

* **Changes**
  * Dashboard header and hint updated for clearer wording.
  * Automatic dashboard launch in new terminal windows is disabled by default.
  * Unfiltered database/list output now shows only the first 20 items and a total count when more exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->