### PR TITLE
info

### DIFF
--- a/files/zsh/gsd.zsh
+++ b/files/zsh/gsd.zsh
@@ -110,7 +110,12 @@ info() {
     fi
   fi
 
-  [[ "$found" == "false" ]] && echo -e "\nNot a registered project"
+  # Unregistered git repo on default branch: show recent commits
+  if [[ "$found" == "false" && -d .git ]]; then
+    local default=$(_default_branch 2>/dev/null)
+    local branch=$(git branch --show-current 2>/dev/null)
+    [[ "$branch" == "$default" ]] && { echo ""; commits 6; }
+  fi
 }
 
 # List all GSD projects with live state from STATE.md


### PR DESCRIPTION
show recent commits for unregistered repos on default branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced information display for unregistered projects. When a project is not registered but exists in a git repository, the tool now displays the six most recent commits when on the default branch, providing more useful context instead of showing a registration message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->