### PR TITLE
remap tilde

### DIFF
--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -43,6 +43,24 @@
                 ]
               }
             ]
+          },
+          {
+            "description": "⌘/ to ⌘~ (switch windows)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "slash",
+                  "modifiers": { "mandatory": ["command"] }
+                },
+                "to": [
+                  {
+                    "key_code": "grave_accent_and_tilde",
+                    "modifiers": ["command"]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -208,7 +208,7 @@
   copy:
     src: karabiner/karabiner.json
     dest: "{{ ansible_env.HOME }}/.config/karabiner/karabiner.json"
-    force: no
+    force: yes
 
 - name: Install/update GSD (always runs for latest)
   ansible.builtin.command: npx get-shit-done-cc@latest --global


### PR DESCRIPTION
remap Cmd+/ to Cmd+~ for window switching

- Add Karabiner rule mapping Cmd+/ to Cmd+~ (grave_accent_and_tilde)
- Change karabiner.json Ansible copy to force:yes so updates apply

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new keyboard shortcut: Command + / maps to Command + `, providing quick window switching.

* **Chores**
  * Configuration synchronization now force-overwrites the local keyboard configuration to ensure the latest settings are applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->