### PR TITLE
hub improve

### DIFF
--- a/files/claude/commands/amend.md
+++ b/files/claude/commands/amend.md
@@ -1,0 +1,33 @@
+## Amend Commit
+
+**Goal:** Amend the last commit, updating the timestamp and message body.
+
+**Arguments:** `$ARGUMENTS`
+- No arguments: amend with only already-staged changes
+- `add`: run `git add .` first, then amend (brings in all changes)
+
+## Steps
+
+1. **If `$ARGUMENTS` contains `add`:**
+   ```bash
+   git add .
+   ```
+   Otherwise, skip — only already-staged files will be included.
+
+2. **Amend the commit** with `--reset-author` to update the timestamp:
+   - Keep the existing subject line
+   - Add or update the body to describe what changed in this amend
+   - Use heredoc for the message
+
+3. **Format:**
+   ```bash
+   git commit --amend --reset-author -m "$(cat <<'EOF'
+   <existing subject>
+
+   <new or updated body describing the amendment>
+   EOF
+   )"
+   ```
+
+4. **After amend, run review:**
+   Then invoke `/review 2` to get feedback before pushing.

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -32,10 +32,30 @@ _claude_run() {
   return $ret
 }
 
-claude() { _claude_run --permission-mode plan "$@"; }
-clauden() { _claude_run "$@"; }
-claudev() { _claude_run --permission-mode plan --append-system-prompt "Always respond using the mcp__voicemode__converse tool to speak your responses aloud." "$@"; }
-claudevn() { _claude_run --append-system-prompt "Always respond using the mcp__voicemode__converse tool to speak your responses aloud." "$@"; }
+_claude_maybe_gsd() {
+  local -a flags=("$@")
+  [[ -f .planning/STATE.md ]] && flags+=("go")
+  _claude_run "${flags[@]}"
+}
+
+claude() {
+  [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan; return; }
+  _claude_run --permission-mode plan "$@"
+}
+clauden() {
+  [[ $# -eq 0 ]] && { _claude_maybe_gsd; return; }
+  _claude_run "$@"
+}
+claudev() {
+  local voice='Always respond using the mcp__voicemode__converse tool to speak your responses aloud.'
+  [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan --append-system-prompt "$voice"; return; }
+  _claude_run --permission-mode plan --append-system-prompt "$voice" "$@"
+}
+claudevn() {
+  local voice='Always respond using the mcp__voicemode__converse tool to speak your responses aloud.'
+  [[ $# -eq 0 ]] && { _claude_maybe_gsd --append-system-prompt "$voice"; return; }
+  _claude_run --append-system-prompt "$voice" "$@"
+}
 
 claudewright() {
   claude mcp add playwright npx @playwright/mcp@latest


### PR DESCRIPTION
improve hub CLI with subcommands and navigation

- Restructure hub() as dispatcher with create/rm/number subcommands
- Add hub <number> navigation via _hub_nav helper
- Support hub rm <name> to remove by name, not just current path
- Extract create and rm logic into private functions
- Remove navigation from hubs() listing function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized hub CLI into a single entrypoint that routes subcommands and consolidated removal logic; preserved listing/status behavior.

* **New Features**
  * Hub subcommands: create/register current directory, remove by name/path, navigate by index or name, and improved no-arg help.
  * Claude CLI variants auto-handle zero-arg behavior and support voice prompts.
  * System reminder auto-detects local GSD projects and appends project guidance.
  * Added docs for amending the last Git commit.

* **Bug Fixes**
  * Safer registry updates with write-then-validate flow and clearer error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->