### PR TITLE
releases fix

### DIFF
--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -7,7 +7,7 @@ _git_sync() {
 
   if [[ "$current_branch" = "$default" ]]; then
     echo "🕵️ Checking for new commits 🔎"
-    git pull origin "$default"
+    git pull --tags origin "$default"
     return
   fi
 
@@ -113,7 +113,7 @@ releases () { # List releases for repo # ➜ releases 5
     return
   fi
   [[ $1 ]] && no=$1 || no=500
-  git for-each-ref --sort=taggerdate --format '%(refname:short) %(taggerdate:relative)' refs/tags | grep ago | sort -Vr | head -n $no | awk '{tag = $1; date = $2 " " $3 " " $4 " " $5 " " $6; printf "\033[0;32m%-7s \033[1;0m%-s\n", tag, date}'
+  git for-each-ref --sort=-creatordate --format '%(refname:short) %(creatordate:relative)' refs/tags | head -n $no | awk '{tag = $1; date = $2 " " $3 " " $4 " " $5 " " $6; printf "\033[0;32m%-7s \033[1;0m%-s\n", tag, date}'
 }
 
 prs () { # List open prs


### PR DESCRIPTION
show latest releases including lightweight tags

- Use creatordate instead of taggerdate to support both lightweight and annotated tags
- Fetch tags on git pull to main so new CI releases appear locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Default-branch sync now fetches and includes tags automatically when updating from the remote.
  * Release tag selection and sorting logic refined for more consistent and reliable identification of recent releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->