### PR TITLE
tab title and linearctl

### DIFF
--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -438,6 +438,15 @@ gtop () {
   cd $(git rev-parse --show-toplevel)
 }
 
+mv () { # git mv in repos, regular mv otherwise # ➜ mv old.txt new.txt
+  if [[ "$1" != -* ]] && git rev-parse --is-inside-work-tree &>/dev/null \
+    && { git ls-files --error-unmatch "$1" &>/dev/null || { [[ -d "$1" ]] && git ls-files -- "$1/" | read -r; }; }; then
+    git mv "$@" 2>/dev/null || command mv "$@"
+  else
+    command mv "$@"
+  fi
+}
+
 ginit () {
   git init
   if [ ! -f package.json ]

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -187,24 +187,35 @@ start () {
   browser-sync start --server $type "*.*" --port $port --ui-port $ui_port
 }
 
-awks () {
-  echo awk -F\' \' \'{print \$2}\'
+awks () { # awk field shortcut # ➜ awks , 3
+  if [[ $# -eq 0 ]]; then
+    echo "Usage: command | awks [delimiter] <field>"
+    echo "       command | awks <field>  (space delimiter)"
+    return
+  fi
+  if [[ $# -eq 1 ]]; then
+    [[ "$1" =~ ^[0-9]+$ ]] && awk '{print $'"$1"'}' || awk -F"$1" '{print $2}'
+    return
+  fi
+  awk -F"$1" '{print $'"$2"'}'
 }
 
-tab_title() {
-  print -Pn "\e]1;${1}\a"  # Set only tab title, preserve window title
-}
-
-# Custom preexec using zsh hooks - sets tab title to command name
-my_preexec() {
-  local cmd="${1%% *}"
-  cmd="${cmd##*/}"
-  tab_title "$cmd"
-}
-
-# Add the hook
 autoload -Uz add-zsh-hook
-add-zsh-hook preexec my_preexec
+
+_last_tab_title=""
+
+_set_titles() {
+  print -n -- "\e]2;${PWD##*/}\a"
+  [[ -n "$_last_tab_title" ]] && print -n -- "\e]1;${_last_tab_title}\a"
+}
+_set_tab_title() {
+  _last_tab_title="$1"
+  print -n -- "\e]1;${1}\a"
+}
+
+_set_titles
+add-zsh-hook precmd _set_titles
+add-zsh-hook preexec _set_tab_title
 
 sw () {
     if [[ -n $1 ]]

--- a/files/zsh/nav.zsh
+++ b/files/zsh/nav.zsh
@@ -25,19 +25,6 @@ mcd() {
   cd "$1"
 }
 
-# Override cd to set window title
-cd() {
-  builtin cd "$@" && {
-    print -Pn "\e]2;$(basename "$PWD")\a"
-  }
-}
-
-# Set initial window title when shell starts
-if [[ -z "$_window_title_set" ]]; then
-  print -Pn "\e]2;$(basename "$PWD")\a"
-  _window_title_set=1
-fi
-
 # Marks system
 
 jump() {

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -120,6 +120,7 @@
     - "browser-sync"
     - "surge"
     - "agent-browser"
+    - "linearctl"
 
 - name: pip installs
   pip:


### PR DESCRIPTION
improve terminal titles, add linearctl and mv wrapper

- terminal titles: window shows directory via precmd, tab shows last command via preexec
- linearctl: add to install role
- mv: wrapper that tries git mv first with fallback to mv
- awks: update awks function to take parameters and act, not just display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git-aware file moving: prefers git mv inside repositories with fallback to mv
  * Enhanced awk utility with more flexible argument and field handling
  * Added linearctl to default npm packages

* **Refactor**
  * Redesigned terminal tab/window title handling for more reliable updates and single-tab behavior
  * Replaced older title wrappers with a unified hook-driven lifecycle

* **Bug Fixes**
  * Title update errors are now logged and do not crash the shell session
<!-- end of auto-generated comment: release notes by coderabbit.ai -->