### PR TITLE
changelog when squash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,28 +13,27 @@ jobs:
       DEPLOY_URL: macfair.io37.ch
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           release-count: "0"
-
-      - name: Print the changelog
-        run: echo "${{ steps.changelog.outputs.tag }}"
-
-      - name: Print the changelog
-        run: echo "${{ steps.changelog.outputs.version }}"
-
-      - name: Print the changelog
-        run: echo "${{ steps.changelog.outputs.clean_changelog }}" > notes.text
+          version-file: "package.json"
+          git-user-name: 'github-actions[bot]'
+          git-user-email: '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Create Release
-        run: gh release create ${{ steps.changelog.outputs.tag  }} --notes-file notes.text
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ steps.changelog.outputs.tag }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          draft: false
+          prerelease: false
 
       - name: make a gitconfig
         run: |


### PR DESCRIPTION
guard release step for squash-merge compatibility

- Upgrade actions/checkout v3 to v4 and conventional-changelog-action v3 to v5
- Guard release creation with tag output check so workflow succeeds when no conventional commits found
- Switch from gh CLI to softprops/action-gh-release@v2
- Remove debug print steps