### PR TITLE
replace voice mode with speak skill

### DIFF
--- a/files/claude/hooks/security-validator.ts
+++ b/files/claude/hooks/security-validator.ts
@@ -150,6 +150,11 @@ function validateCommand(command: string): { allowed: boolean; message?: string;
     return { allowed: true }
   }
 
+  // Allowlist: Kokoro TTS localhost API
+  if (/^curl\s+-s\s+-X\s+POST\s+http:\/\/127\.0\.0\.1:8880\/v1\/audio\/speech\b/.test(command)) {
+    return { allowed: true }
+  }
+
   // Check each tier
   for (const [tierName, tier] of Object.entries(ATTACK_PATTERNS)) {
     for (const pattern of tier.patterns) {

--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -5,13 +5,8 @@
     "command": "~/.claude/statusline.sh",
     "padding": 0
   },
-  "enabledPlugins": {
-    "voicemode@mbailey": true
-  },
   "permissions": {
     "allow": [
-      "mcp__voicemode__*",
-      "mcp__plugin_voicemode_voicemode__*",
       "mcp__playwright__browser_navigate",
       "mcp__playwright__browser_navigate_back",
       "mcp__playwright__browser_click",
@@ -46,7 +41,9 @@
       "Bash(pnpm add *)",
       "Bash(pnpm exec prisma *)",
       "Bash(git *)",
-      "Bash(nightshift:*)"
+      "Bash(nightshift:*)",
+      "Bash(curl -s -X POST http://127.0.0.1:8880/v1/audio/speech *)",
+      "Bash(afplay /tmp/claude_speak*)"
     ],
     "deny": [
       "Bash(git push *)",

--- a/files/claude/skills/speak/skill.md
+++ b/files/claude/skills/speak/skill.md
@@ -1,0 +1,41 @@
+---
+name: speak
+description: Speak a response aloud using Kokoro TTS. Use when the user asks you to say something out loud or wants voice output.
+user_invocable: true
+---
+
+# Speak
+
+Speak text aloud using the local Kokoro TTS service on port 8880.
+
+## When to Use
+
+- User says "speak", "say that", "read that aloud", "tell me out loud"
+- User asks for voice/audio output
+
+## Instructions
+
+1. Compose a natural spoken version of your response. Strip markdown, code blocks, bullet points - write it as you'd say it conversationally. Keep it concise.
+2. Type the response normally so the user has it in the terminal.
+3. Run curl to generate the audio:
+   ```bash
+   curl -s -X POST http://127.0.0.1:8880/v1/audio/speech -H "Content-Type: application/json" -d '{"model":"kokoro","input":"<spoken text here>","voice":"af_sky","response_format":"mp3"}' -o /tmp/claude_speak.mp3
+   ```
+4. Run afplay as a SEPARATE Bash call:
+   ```bash
+   afplay /tmp/claude_speak.mp3
+   ```
+
+IMPORTANT — follow these EXACTLY or permissions will break:
+- Output to `/tmp/claude_speak.mp3` (system temp dir, always exists — do NOT use project `tmp/`)
+
+## Voice Options
+
+ALWAYS use `af_sky`
+
+## Troubleshooting
+
+If Kokoro isn't running, fall back to macOS `say`:
+```bash
+say -v Samantha "<spoken text here>"
+```

--- a/files/claude/skills/speak/speak.sh
+++ b/files/claude/skills/speak/speak.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+VOICE="${1:-af_sky}"
+TEXT="$(cat /tmp/claude_speak.txt)"
+[[ -z "$TEXT" ]] && echo "No text in /tmp/claude_speak.txt" && exit 1
+curl -s -X POST http://127.0.0.1:8880/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg text "$TEXT" --arg voice "$VOICE" '{model:"kokoro",input:$text,voice:$voice,response_format:"mp3"}')" \
+  -o /tmp/claude_speak.mp3 && afplay /tmp/claude_speak.mp3

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -47,12 +47,12 @@ clauden() {
   _claude_run "$@"
 }
 claudev() {
-  local voice='Always respond using the mcp__voicemode__converse tool to speak your responses aloud.'
+  local voice='Always speak responses aloud using the /speak skill. Every response should be voiced via Kokoro TTS.'
   [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan --append-system-prompt "$voice"; return; }
   _claude_run --permission-mode plan --append-system-prompt "$voice" "$@"
 }
 claudevn() {
-  local voice='Always respond using the mcp__voicemode__converse tool to speak your responses aloud.'
+  local voice='Always speak responses aloud using the /speak skill. Every response should be voiced via Kokoro TTS.'
   [[ $# -eq 0 ]] && { _claude_maybe_gsd --append-system-prompt "$voice"; return; }
   _claude_run --append-system-prompt "$voice" "$@"
 }


### PR DESCRIPTION
replace voicemode plugin with local Kokoro TTS speak skill

- Add /speak skill using Kokoro TTS via localhost API
- Remove voicemode MCP plugin configuration
- Add curl and afplay permissions for TTS playback
- Allowlist localhost:8880 in security validator
- Update claudev/claudevn shell aliases to use /speak skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text-to-speech support with multiple voice options and a new "Speak" skill to convert text to spoken audio, including a macOS fallback.

* **Refactor**
  * Updated voice prompts to use the new local TTS integration.

* **Chores**
  * Removed the deprecated voicemode plugin and adjusted local playback permissions for the new TTS workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->