### PR TITLE
rhyl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
           source ~/.pyvenv-ansible/bin/activate
           ansible-galaxy collection install -r requirements.yml
 
+      - name: Replace tracked files with CI-safe versions
+        run: |
+          printf '[macbook]\n\n[debian]\n\n[sites]\n' > hosts
+          printf 'users:\nroot:\n' > host_vars/localhost.yml
+
       - name: makes this target
         run: |
           source ~/.pyvenv-ansible/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
 roles/.DS_Store
-host_vars/*
 group_vars/*
 group_vars/all/vars.yml
-!host_vars/example.yml
 !group_vars/all/example.yml
-hosts
 TODO.md
 TODO*.md
 sites/*yml

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ commands:
 ansible:
 	python3 -m venv ~/.pyvenv-ansible
 	source ~/.pyvenv-ansible/bin/activate && python3 -m pip install --upgrade pip
-	source ~/.pyvenv-ansible/bin/activate && python3 -m pip install ansible
+	source ~/.pyvenv-ansible/bin/activate && python3 -m pip install ansible passlib
 	$(ANSIBLE_GALAXY) collection install -r requirements.yml
 thiscomputer:
 	$(ANSIBLE_PLAYBOOK) thiscomputer.yml --ask-become-pass -e "hostname=`hostname`"

--- a/files/ssh/conf.d/10_servers.conf
+++ b/files/ssh/conf.d/10_servers.conf
@@ -1,0 +1,34 @@
+Host stolac stolac.rakio.cc
+    User deploy
+    Hostname stolac.rakio.cc
+    IdentityFile ~/.ssh/stolac/deploy_ed25519
+
+Host kawajevo kawajevo.io37.ch
+    User deploy
+    Hostname io37.ch
+    IdentityFile ~/.ssh/kawajevo/deploy_rsa
+
+Host rhyl
+    User deploy
+    Hostname rhyl.io37.ch
+    IdentityFile ~/.ssh/rhyl/id_rsa
+
+Host dokku
+    User dokku
+    Hostname ol14.cc
+    IdentityFile ~/.ssh/ol14.cc/dokku_rsa
+
+Host ol14.cc
+    User dokku
+    Hostname 64.23.226.251
+    IdentityFile ~/.ssh/ol14.cc/dokku_rsa
+
+Host herceg
+    User herceg
+    Hostname 192.168.1.8
+    IdentityFile ~/.ssh/id_rsa
+
+Host pi
+    User chester
+    Hostname a.chester.pi
+    IdentityFile ~/.ssh/id_rsa

--- a/files/ssh/conf.d/20_tunnels.conf
+++ b/files/ssh/conf.d/20_tunnels.conf
@@ -1,0 +1,15 @@
+Host tunnel
+    HostName 207.180.194.212
+    User tunnel
+    IdentityFile ~/.ssh/tunnel_key
+    RemoteForward *:11560 localhost:6520
+    SessionType none
+    RequestTTY no
+
+Host sutomore
+    HostName 207.180.194.212
+    User tunnel
+    IdentityFile ~/.ssh/tunnel_key
+    RemoteForward *:19995 localhost:19995
+    SessionType none
+    RequestTTY no

--- a/files/ssh/conf.d/30_services.conf
+++ b/files/ssh/conf.d/30_services.conf
@@ -1,0 +1,4 @@
+Host github.com
+    IdentityFile ~/.ssh/gh/id_rsa
+    IgnoreUnknown UseKeychain
+    UseKeychain yes

--- a/files/ssh/config
+++ b/files/ssh/config
@@ -1,0 +1,9 @@
+# Added by OrbStack: 'orb' SSH host for Linux machines
+# This only works if it's at the top of ssh_config (before any Host blocks).
+# This won't be added again if you remove it.
+Include ~/.orbstack/ssh/config
+
+Include ~/.ssh/conf.d/*.conf
+
+Host *
+    ServerAliveInterval 60

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -1,7 +1,7 @@
 # Claude Code helpers
 
 # Remove any old aliases to allow function definitions
-unalias claude clauden claudev claudevn claudep claudevp claudex claudepod 2>/dev/null
+unalias claude clauden claudev claudevn claudep claudevp claudex claudepod discuss 2>/dev/null
 
 CLAUDE_LOCKFILE=".claude-session.lock"
 
@@ -65,6 +65,12 @@ claudex() {
     -w /work \
     claudepod \
     claude --dangerously-skip-permissions "$@"
+}
+
+discuss() {
+  local voice='Always speak every response aloud using the /speak skill (Kokoro TTS on port 8880, then afplay). Skip code blocks in the spoken version - focus on reasoning, strategy, and discussion. The user can see the full text on screen, so the spoken part should be conversational.'
+  [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan --append-system-prompt "$voice"; return; }
+  _claude_run --permission-mode plan --append-system-prompt "$voice" "$@"
 }
 
 claudewright() {

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -469,12 +469,13 @@ findg () { # find with grep filter # ➜ findg package.json
 }
 
 sshs () { # List or show SSH hosts # ➜ sshs | sshs pi | sshs -e
+  local _dir="$HOME/.ssh/conf.d"
   if [[ "$1" == "-e" ]]; then
-    ${EDITOR:-vi} ~/.ssh/config
+    ${EDITOR:-vi} "$_dir"
   elif [[ -z "$1" ]]; then
-    grep '^Host ' ~/.ssh/config | awk '{print $2}' | grep -v '\*'
+    grep '^Host ' "$_dir"/*.conf | awk '{print $2}' | grep -v '\*'
   else
-    awk -v h="$1" '/^Host /{p=($2==h)} p' ~/.ssh/config
+    awk -v h="$1" '/^Host /{p=($2==h)} p' "$_dir"/*.conf
   fi
 }
 

--- a/host_vars/kawajevo.io37.ch/vars.yml
+++ b/host_vars/kawajevo.io37.ch/vars.yml
@@ -1,0 +1,9 @@
+ansible_user: "deploy"
+ansible_ssh_private_key_file: "~/.ssh/kawajevo/deploy_rsa"
+to_sudo:
+  - deploy
+iterm_theme: "coffee"
+zsh_theme: "cerico-w-user"
+optional:
+  - docker
+  - agent

--- a/host_vars/kiseljak.localhost/vars.yml
+++ b/host_vars/kiseljak.localhost/vars.yml
@@ -1,0 +1,3 @@
+ansible_connection: local
+iterm_theme: "coffee"
+zsh_theme: "cerico-w-user"

--- a/host_vars/localhost.yml
+++ b/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+users:
+  - { username: deploy@stolac.rakio.cc, userkey: ~/.ssh/stolac/deploy_ed25519.pub }
+root: []

--- a/host_vars/stolac.rakio.cc/vars.yml
+++ b/host_vars/stolac.rakio.cc/vars.yml
@@ -1,0 +1,6 @@
+ansible_user: "deploy"
+ansible_ssh_private_key_file: "~/.ssh/stolac/deploy_ed25519"
+to_sudo:
+  - deploy
+iterm_theme: "daegu"
+zsh_theme: "cerico-w-user"

--- a/hosts
+++ b/hosts
@@ -1,0 +1,8 @@
+[macbook]
+kiseljak.localhost
+
+[debian]
+stolac.rakio.cc
+kawajevo.io37.ch
+
+[sites]

--- a/keys/keys.yml
+++ b/keys/keys.yml
@@ -32,10 +32,33 @@
       when: 'inventory_hostname in item.username'
       become: true
       become_user: root
+      register: password_config
+
+    - name: Verify deploy can sudo
+      ansible.builtin.command: sudo -n whoami
+      register: sudo_check
+      ignore_errors: true
+      become: false
+
+    - name: Disable root SSH login
+      copy:
+        content: "PermitRootLogin no\n"
+        dest: /etc/ssh/sshd_config.d/20-disable-root-login.conf
+        mode: '0644'
+      when: sudo_check.stdout == "root"
+      become: true
+      become_user: root
+      register: root_login_config
+
+    - name: Warn if deploy cannot sudo
+      debug:
+        msg: "WARNING: deploy cannot sudo on {{ inventory_hostname }}. Root login NOT disabled. Run make setup first."
+      when: sudo_check.rc != 0
 
     - name: Restart ssh
       ansible.builtin.service:
-        name: sshd
+        name: ssh
         state: restarted
       become: true
       become_user: root
+      when: password_config is changed or (root_login_config is defined and root_login_config is changed)

--- a/makefiles/roles.mk
+++ b/makefiles/roles.mk
@@ -1,7 +1,7 @@
 # Ansible tag targets - auto-generated from ANSIBLE_TAGS list
 # To add a new target, just add the tag name to ANSIBLE_TAGS
 
-ANSIBLE_TAGS := terminal install debian nginx rails vscode functions claude keepalive diskspace desktop ruben agent
+ANSIBLE_TAGS := terminal install debian nginx rails vscode functions claude keepalive diskspace desktop ruben agent ssh
 
 define ansible_tag
 .PHONY: $(1)

--- a/roles/install/tasks/debian.yml
+++ b/roles/install/tasks/debian.yml
@@ -37,6 +37,7 @@
       - jq
       - nginx
       - python3-pip
+      - python3-setuptools
       - snapd
       - figlet
       - ufw
@@ -117,30 +118,53 @@
   become_user: root
   ignore_errors: true
 
-- name: Install certbot snap with option --classic
+- name: Install certbot via apt (Debian)
+  apt:
+    name:
+      - certbot
+      - python3-certbot-nginx
+    state: present
+  become: true
+  become_user: root
+  when: ansible_distribution == "Debian"
+
+- name: Install certbot snap with option --classic (Ubuntu)
   command: snap install certbot --classic
   become: true
   become_user: root
+  when: ansible_distribution == "Ubuntu"
 
-- name: create certbot cron file if it doesnt exist
+- name: create certbot cron file if it doesnt exist (Ubuntu)
   copy:
     content: ""
     dest: /etc/cron.d/cert
     force: no
   become: true
   become_user: root
+  when: ansible_distribution == "Ubuntu"
 
-- name: Add certbot renewals to cron
+- name: Add certbot renewals to cron (Ubuntu)
   lineinfile:
     path: /etc/cron.d/cert
     line: 5 4 * * 2 root /snap/bin/certbot renew
     insertbefore: BOF
   become: true
   become_user: root
+  when: ansible_distribution == "Ubuntu"
+
+- name: Enable certbot.timer (Debian)
+  ansible.builtin.systemd:
+    name: certbot.timer
+    enabled: true
+    state: started
+  become: true
+  become_user: root
+  when: ansible_distribution == "Debian"
 
 - name: pip installs
   pip:
     name: "{{ item }}"
+    extra_args: --break-system-packages
   with_items:
     - "jmespath"
     - "passlib"

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Create conf.d directory
+  file:
+    path: "~{{ macbook_user.stdout }}/.ssh/conf.d"
+    state: directory
+    mode: "0700"
+
+- name: Find existing conf.d files
+  find:
+    paths: "~{{ macbook_user.stdout }}/.ssh/conf.d"
+    patterns: "*.conf"
+  register: existing_conf_files
+
+- name: Build list of managed conf.d filenames
+  set_fact:
+    managed_conf_files: "{{ lookup('fileglob', 'ssh/conf.d/*.conf', wantlist=True) | map('basename') | list }}"
+
+- name: Remove stale conf.d files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ existing_conf_files.files }}"
+  when: item.path | basename not in managed_conf_files
+
+- name: Copy conf.d files
+  copy:
+    src: "{{ item }}"
+    dest: "~{{ macbook_user.stdout }}/.ssh/conf.d/"
+    mode: "0600"
+  with_fileglob:
+    - ssh/conf.d/*.conf
+
+- name: Copy SSH config
+  copy:
+    src: ssh/config
+    dest: "~{{ macbook_user.stdout }}/.ssh/config"
+    mode: "0600"
+    backup: yes
+
+- name: configure ssh for mac
+  when: ansible_os_family == "Darwin"
+  block:
+    - name: print role name
+      set_fact:
+        parent_role_name: "{{ role_name }}"
+
+    - name: add version
+      include_role:
+        name: version

--- a/setup.yml
+++ b/setup.yml
@@ -26,6 +26,7 @@
 - name: Setup macbook
   hosts: macbook
   roles:
+    - { role: ssh, tags: [ssh, setup, info] }
     - { role: vscode, tags: [vscode, setup, info] }
     - { role: desktop, tags: [desktop, setup, info] }
     - { role: keepalive, tags: [keepalive, functions, setup, info] }


### PR DESCRIPTION
modularize SSH config, provision stolac, and harden root login

- Add SSH conf.d role with stale file cleanup for managed config deployment
- Consolidate server entries into 10_servers.conf with tunnels and services
- Remove stale Picfair and dead kawajevo root entries
- Add stolac host vars and Debian 13 compatibility for certbot/packages
- Disable root SSH login on managed servers after verifying deploy can sudo
- Fix sshd service name to ssh for Ubuntu compatibility
- Add hosts inventory with macbook, debian, and sites groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modular SSH config (per-host conf.d, global keepalive), tunnels, and service keys
  * New shell command "discuss" for voice-based interactions
  * CI now seeds a minimal hosts inventory for tests

* **Chores**
  * Added host inventory entries and per-host connection settings
  * Included SSH role in macOS setup and ansible tag targets
  * Packaging/install updates: distro-aware certbot handling and expanded pip installs

* **Bug Fixes**
  * Added sudo checks and conditional task to disable root SSH login
<!-- end of auto-generated comment: release notes by coderabbit.ai -->