### PR TITLE
speak function add mcp remove

### DIFF
--- a/files/bin/speak
+++ b/files/bin/speak
@@ -1,0 +1,24 @@
+#!/bin/zsh
+# Speak text or file contents using Kokoro TTS
+
+_speak() {
+  jq -n --arg text "$1" \
+    '{model:"kokoro", input:$text, voice:"af_sky", response_format:"mp3"}' | \
+    curl -s -X POST http://127.0.0.1:8880/v1/audio/speech \
+      -H "Content-Type: application/json" \
+      -d @- \
+      -o /tmp/speak_out.mp3 && afplay /tmp/speak_out.mp3
+}
+
+[[ $# -eq 0 ]] && _speak "Nothing to speak." && exit 1
+
+# If argument is a file, read its contents
+if [[ -f "$1" ]]; then
+  if [[ "$1" == *.json ]] && jq -e '.input' "$1" &>/dev/null; then
+    _speak "$(jq -r '.input' "$1")"
+  else
+    _speak "$(cat "$1")"
+  fi
+else
+  _speak "$*"
+fi

--- a/files/claude/settings.json
+++ b/files/claude/settings.json
@@ -41,9 +41,14 @@
       "Bash(pnpm add *)",
       "Bash(pnpm exec prisma *)",
       "Bash(git *)",
+      "Bash(gh issue *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh api --method GET *)",
+      "Bash(semgrep *)",
       "Bash(nightshift:*)",
-      "Bash(curl -s -X POST http://127.0.0.1:8880/v1/audio/speech *)",
-      "Bash(afplay /tmp/claude_speak*)"
+      "Bash(/usr/local/bin/speak *)"
     ],
     "deny": [
       "Bash(git push *)",

--- a/files/claude/skills/speak/skill.md
+++ b/files/claude/skills/speak/skill.md
@@ -17,25 +17,27 @@ Speak text aloud using the local Kokoro TTS service on port 8880.
 
 1. Compose a natural spoken version of your response. Strip markdown, code blocks, bullet points - write it as you'd say it conversationally. Keep it concise.
 2. Type the response normally so the user has it in the terminal.
-3. Run curl to generate the audio:
+3. Run the speak script via Bash:
    ```bash
-   curl -s -X POST http://127.0.0.1:8880/v1/audio/speech -H "Content-Type: application/json" -d '{"model":"kokoro","input":"<spoken text here>","voice":"af_sky","response_format":"mp3"}' -o /tmp/claude_speak.mp3
-   ```
-4. Run afplay as a SEPARATE Bash call:
-   ```bash
-   afplay /tmp/claude_speak.mp3
+   /usr/local/bin/speak "Your spoken text here"
    ```
 
-IMPORTANT — follow these EXACTLY or permissions will break:
-- Output to `/tmp/claude_speak.mp3` (system temp dir, always exists — do NOT use project `tmp/`)
+That's it. The speak script handles JSON encoding via jq, calls Kokoro, and plays the audio.
+
+IMPORTANT:
+- Use double quotes around the text argument
+- Escape any double quotes inside the text with backslash
+- For long responses (500+ words), split into multiple speak calls
+- The permission pattern `Bash(/usr/local/bin/speak *)` auto-approves these calls
+- Works in both normal mode and plan mode (no Write tool needed)
 
 ## Voice Options
 
-ALWAYS use `af_sky`
+ALWAYS uses `af_sky` (configured in the speak script).
 
 ## Troubleshooting
 
 If Kokoro isn't running, fall back to macOS `say`:
 ```bash
-say -v Samantha "<spoken text here>"
+say -v Samantha "spoken text here"
 ```

--- a/files/git/ignore
+++ b/files/git/ignore
@@ -83,4 +83,5 @@ CLAUDE.md
 .cursorrules
 .terminal-profile
 .planning
+claude_tts.json
 tmp

--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -61,6 +61,28 @@
                 ]
               }
             ]
+          },
+          {
+            "description": "⌘; to /speak + SuperWhisper",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "semicolon",
+                  "modifiers": { "mandatory": ["command"] }
+                },
+                "to": [
+                  { "key_code": "slash" },
+                  { "key_code": "s" },
+                  { "key_code": "p" },
+                  { "key_code": "e" },
+                  { "key_code": "a" },
+                  { "key_code": "k" },
+                  { "key_code": "spacebar" },
+                  { "key_code": "period", "modifiers": ["command"] }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/files/zsh/darwin/diskspace.zsh
+++ b/files/zsh/darwin/diskspace.zsh
@@ -57,7 +57,7 @@ diskclean () {
     for f in "${snapshots[@]:5}"; do rm -- "$f"; done 2>/dev/null
   fi
   rm -rf ~/.claude/debug 2>/dev/null
-  rm -rf ~/.claude/projects 2>/dev/null
+  rm -rf ~/.claude/file-history 2>/dev/null
 
   echo "After: $(diskfree)"
 }

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -72,132 +72,31 @@
     src: claude/config.md
     dest: ~{{ macbook_user.stdout }}/.gemini/GEMINI.md
 
-- name: Get list of installed MCP servers
-  ansible.builtin.shell: claude mcp list 2>/dev/null || echo ""
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  register: mcp_list
-  changed_when: false
-
-- name: Add Prisma MCP server
-  ansible.builtin.shell: claude mcp add -s user prisma -- npx prisma mcp
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  when: "'prisma' not in mcp_list.stdout"
-  ignore_errors: true
-
-- name: Add Semgrep MCP server
-  ansible.builtin.shell: claude mcp add -s user semgrep -- semgrep mcp
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  when: "'semgrep' not in mcp_list.stdout"
-  ignore_errors: true
-
-- name: Add Playwright MCP server
-  ansible.builtin.shell: claude mcp add -s user playwright -- npx @playwright/mcp@latest
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  when: "'playwright' not in mcp_list.stdout"
-  ignore_errors: true
-
-- name: Add voicemode marketplace
-  ansible.builtin.shell: claude plugin marketplace add https://github.com/mbailey/claude-plugins
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  args:
-    creates: "{{ ansible_env.HOME }}/.claude/plugins/marketplaces/mbailey"
-  ignore_errors: true
-
-- name: Install voicemode plugin
-  ansible.builtin.shell: claude plugin install voicemode@mbailey
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  args:
-    creates: "{{ ansible_env.HOME }}/.claude/plugins/cache/mbailey/voicemode"
-  ignore_errors: true
-
-- name: Install Kokoro TTS via voicemode
-  ansible.builtin.shell: claude /voicemode:install kokoro
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  args:
-    creates: "{{ ansible_env.HOME }}/.voicemode/services/kokoro"
-  ignore_errors: true
-
-- name: Add claude-stt marketplace
-  ansible.builtin.shell: claude plugin marketplace add jarrodwatts/claude-stt
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  args:
-    creates: "{{ ansible_env.HOME }}/.claude/plugins/marketplaces/jarrodwatts-claude-stt"
-  ignore_errors: true
-
-- name: Install claude-stt plugin
-  ansible.builtin.shell: claude plugin install claude-stt
-  environment:
-    PATH: "/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  args:
-    creates: "{{ ansible_env.HOME }}/.claude/plugins/cache/jarrodwatts-claude-stt/claude-stt"
-  ignore_errors: true
-
-- name: Find all claude-stt plugin version directories
-  ansible.builtin.find:
-    paths: "{{ ansible_env.HOME }}/.claude/plugins/cache/jarrodwatts-claude-stt/claude-stt/"
-    file_type: directory
-  register: claude_stt_versions
-  ignore_errors: true
-
-- name: Run claude-stt setup for each version
-  ansible.builtin.shell: |
-    cd {{ item.path }}
-    uv run --directory . python -m claude_stt.setup --skip-hotkey-test --no-start
+- name: Install typescript-language-server for LSP plugin
+  community.general.npm:
+    name: "{{ item }}"
+    global: true
+    state: present
   environment:
     PATH: "/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-    CLAUDE_PLUGIN_ROOT: "{{ item.path }}"
-  args:
-    creates: "{{ item.path }}/.venv"
-  loop: "{{ claude_stt_versions.files | default([]) }}"
-  when: claude_stt_versions.files is defined
+  loop:
+    - typescript-language-server
+    - typescript
+
+- name: Install Claude Code plugins from official marketplace
+  ansible.builtin.shell: "claude plugin install {{ item }}@claude-plugins-official"
+  environment:
+    PATH: "/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
+  register: plugin_install
+  changed_when: "'already installed' not in plugin_install.stdout"
   ignore_errors: true
-
-- name: Patch claude-stt hooks to use uv (all versions)
-  ansible.builtin.copy:
-    dest: "{{ item.path }}/hooks/hooks.json"
-    content: |
-      {
-        "hooks": {
-          "SessionStart": [
-            {
-              "hooks": [
-                {
-                  "type": "command",
-                  "command": "cd ${CLAUDE_PLUGIN_ROOT} && uv run python -m claude_stt.daemon start --background 2>/dev/null",
-                  "timeout": 5000
-                }
-              ]
-            }
-          ]
-        }
-      }
-  loop: "{{ claude_stt_versions.files | default([]) }}"
-  when: claude_stt_versions.files is defined
-
-- name: claude-stt permissions reminder
-  ansible.builtin.debug:
-    msg: |
-      ╔══════════════════════════════════════════════════════════════════╗
-      ║  claude-stt requires macOS permissions (one-time setup):         ║
-      ║                                                                  ║
-      ║  System Settings → Privacy & Security → Accessibility            ║
-      ║    → Enable your terminal (iTerm/Terminal)                       ║
-      ║                                                                  ║
-      ║  System Settings → Privacy & Security → Input Monitoring         ║
-      ║    → Enable your terminal (iTerm/Terminal)                       ║
-      ║                                                                  ║
-      ║  After granting permissions, restart Claude Code.                ║
-      ║  Press § to start/stop voice recording.                          ║
-      ╚══════════════════════════════════════════════════════════════════╝
-  when: claude_stt_versions.files is defined and claude_stt_versions.files | length > 0
+  loop:
+    - playwright
+    - typescript-lsp
+    - claude-md-management
+    - claude-code-setup
+    - hookify
+    - security-guidance
 
 - name: Create Karabiner config directory
   file:

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -1,30 +1,37 @@
 ---
+- name: Copy speak script
+  ansible.builtin.copy:
+    src: bin/speak
+    dest: /usr/local/bin/speak
+    mode: '0755'
+  become: true
+
 - name: Copy darwin-specific zsh files
-  copy:
+  ansible.builtin.copy:
     src: "{{ item }}"
     dest: "~{{ macbook_user.stdout }}/.zsh/"
   with_fileglob:
     - zsh/darwin/*.zsh
 
 - name: Copy MCP functions
-  copy:
+  ansible.builtin.copy:
     src: zsh/mcp.zsh
     dest: "~{{ macbook_user.stdout }}/.zsh/mcp.zsh"
 
 - name: create empty tokens file only if one doesnt already exist
-  copy:
+  ansible.builtin.copy:
     content: ""
     dest: ~{{ macbook_user.stdout }}/.zsh/tokens.zsh
     force: no
 
 - name: create trial file for new functions if one doesn't already exist
-  copy:
+  ansible.builtin.copy:
     content: "tinker(){\n  echo try out new functions here, not in main file\n}"
     dest: ~{{ macbook_user.stdout }}/.zsh/_trialling.zsh
     force: no
 
 - name: copy js help file
-  copy:
+  ansible.builtin.copy:
     src: help.js
     dest: ~{{ macbook_user.stdout }}/.zsh/help.js
 
@@ -44,7 +51,7 @@
   when: inventory_hostname != 'github-runner.localhost'
 
 - name: Copy dns functions
-  copy:
+  ansible.builtin.copy:
     src: zsh/dns.zsh
     dest: ~{{ macbook_user.stdout }}/.zsh/dns.zsh
 


### PR DESCRIPTION
add speak script and simplify Claude plugin setup

- Add Kokoro TTS speak script with jq for proper JSON escaping
- Deploy speak script to /usr/local/bin with become: true
- Replace MCP server, voicemode, and claude-stt tasks with looped plugin installs
- Add typescript-lsp, claude-md-management, claude-code-setup, hookify, security-guidance plugins
- Add typescript-language-server npm global dependency for LSP plugin
- Allow semgrep in Claude Code permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local text‑to‑speech utility and a keyboard shortcut to speak text or file contents.
* **Chores**
  * Installed a system-wide speak command and updated shell allow‑list entries to support it.
  * Simplified development plugin/setup flow and adjusted system initialization tasks.
  * Added TTS config to the ignore list.
* **Documentation**
  * Updated TTS usage guidance and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->