### PR TITLE
466 path join filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
           source ~/.pyvenv-ansible/bin/activate
           ansible-galaxy collection install -r requirements.yml
 
+      - name: Syntax-check all playbooks
+        run: |
+          source ~/.pyvenv-ansible/bin/activate
+          make verify
+
       - name: Replace tracked files with CI-safe versions
         run: |
           printf '[macbook]\n\n[debian]\n\n[sites]\n' > hosts

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ claudepod:
 	podman build -t claudepod -f files/claude/Containerfile .
 upgrade:
 	$(ANSIBLE_PLAYBOOK) upgrade.yml -i hosts
+verify:
+	@echo "Syntax-checking playbooks..."
+	@for pb in thiscomputer.yml setup.yml newcomputer.yml newsite.yml addpackage.yml upgrade.yml remote_login.yml keys/keys.yml keys/root.yml; do \
+		$(ANSIBLE_PLAYBOOK) --syntax-check $$pb -i hosts -e "hostname=check" && echo "  ✓ $$pb" || exit 1; \
+	done
 %:
 	@$(MAKE) commands
 include makefiles/*.mk

--- a/addpackage.yml
+++ b/addpackage.yml
@@ -32,11 +32,11 @@
 
     - name: Add target to inventory file when debian.
       ansible.builtin.lineinfile:
-        path: "host_vars/{{ menu_selection.user_input }}/vars.yml"
+        path: "{{ ['host_vars', menu_selection.user_input, 'vars.yml'] | path_join }}"
         line: "optional:"
 
     - name: Add new package to host vars.
-      ansible.builtin.lineinfile.lineinfile:
-        path: "host_vars/{{ menu_selection.user_input }}/vars.yml"
+      ansible.builtin.lineinfile:
+        path: "{{ ['host_vars', menu_selection.user_input, 'vars.yml'] | path_join }}"
         line: " - {{ package }}"
         insertafter: "optional:"

--- a/makefiles/claude.mk
+++ b/makefiles/claude.mk
@@ -1,0 +1,1 @@
+VERIFY_TARGETS := verify

--- a/newcomputer.yml
+++ b/newcomputer.yml
@@ -17,28 +17,28 @@
   tasks:
     - name: Create vars folder for new target
       file:
-        path: "{{ playbook_dir }}/host_vars/{{ target }}"
+        path: "{{ [playbook_dir, 'host_vars', target] | path_join }}"
         state: directory
 
     - name: Create main vars yml for target
       template:
         src: vars/target.yml.j2
-        dest: "{{ playbook_dir }}/host_vars/{{ target }}/vars.yml"
+        dest: "{{ [playbook_dir, 'host_vars', target, 'vars.yml'] | path_join }}"
 
     - name: Add target to inventory file.
       ansible.builtin.lineinfile:
-        path: "{{ playbook_dir }}/hosts"
+        path: "{{ [playbook_dir, 'hosts'] | path_join }}"
         line: "{{ target }}"
         insertafter: "\\[{{ group }}\\]"
 
     - name: Add ansible user to ssh list.
       ansible.builtin.lineinfile:
-        path: "{{ playbook_dir }}/host_vars/localhost.yml"
+        path: "{{ [playbook_dir, 'host_vars', 'localhost.yml'] | path_join }}"
         line: "  - { username: {{ user }}@{{ target }}, userkey: ~/.ssh/id_rsa.pub }"
         insertafter: "users"
 
     - name: Add root user to ssh list.
       ansible.builtin.lineinfile:
-        path: "{{ playbook_dir }}/host_vars/localhost.yml"
+        path: "{{ [playbook_dir, 'host_vars', 'localhost.yml'] | path_join }}"
         line: "  - { username: root@{{ target }}, userkey: ~/.ssh/id_rsa.pub }"
         insertafter: "root"

--- a/newsite.yml
+++ b/newsite.yml
@@ -3,7 +3,7 @@
   connection: local
 
   vars:
-    target_dir: "{{ sites_dir | default(playbook_dir + '/../sites') }}"
+    target_dir: "{{ sites_dir | default([playbook_dir, '..', 'sites'] | path_join) }}"
     repo_url: "{{ nginx_repo | default('git@github.com:cerico/nginx-files.git') }}"
     branch_name: "{{ git_branch | default('main') }}"
 
@@ -36,56 +36,56 @@
     - name: Create main yml
       template:
         src: template.yml.j2
-        dest: "{{ target_dir }}/{{ app_name }}.yml"
+        dest: "{{ [target_dir, app_name + '.yml'] | path_join }}"
 
     - name: Ensure files directory in target_dir exists
       file:
-        path: "{{ target_dir }}/files"
+        path: "{{ [target_dir, 'files'] | path_join }}"
         state: directory
         mode: "0755"
 
     - name: Create nginx template
       template:
         src: template.nginx.conf.j2
-        dest: "{{ target_dir }}/files/{{ app_name }}.nginx.conf"
+        dest: "{{ [target_dir, 'files', app_name + '.nginx.conf'] | path_join }}"
 
     - name: Ensure makefiles directory in target_dir exists
       file:
-        path: "{{ target_dir }}/makefiles"
+        path: "{{ [target_dir, 'makefiles'] | path_join }}"
         state: directory
         mode: "0755"
 
     - name: append to makefile.
       template:
-        dest: "{{ target_dir }}/makefiles/{{ app_name }}"
+        dest: "{{ [target_dir, 'makefiles', app_name] | path_join }}"
         src: Makefile.j2
 
     - name: Create site/hosts file if doesnt exist
       ansible.builtin.copy:
         content: "[sites]\n"
-        dest: "{{ target_dir }}/hosts"
+        dest: "{{ [target_dir, 'hosts'] | path_join }}"
         force: false
 
     - name: Add target to inventory file.
       ansible.builtin.lineinfile:
-        path: "{{ target_dir }}/hosts"
+        path: "{{ [target_dir, 'hosts'] | path_join }}"
         line: "{{ app_name }}"
         insertafter: "\\[sites\\]"
 
     - name: Create default site vars directory if doesnt exist
       file:
         state: directory
-        path: "{{ target_dir }}/group_vars/sites"
+        path: "{{ [target_dir, 'group_vars', 'sites'] | path_join }}"
         force: false
 
     - name: Ensure group_vars/sites directory in target_dir exists
       file:
-        path: "{{ target_dir }}/group_vars/sites"
+        path: "{{ [target_dir, 'group_vars', 'sites'] | path_join }}"
         state: directory
         mode: "0755"
 
     - name: Create default site vars if doesnt exit
       copy:
         content: "ansible_user: deploy"
-        dest: "{{ target_dir }}/group_vars/sites/default.yml"
+        dest: "{{ [target_dir, 'group_vars', 'sites', 'default.yml'] | path_join }}"
         force: false

--- a/roles/agent/tasks/main.yml
+++ b/roles/agent/tasks/main.yml
@@ -26,7 +26,7 @@
     - name: Template .env file
       template:
         src: env.j2
-        dest: "{{ agent_deploy_dir }}/.env"
+        dest: "{{ [agent_deploy_dir, '.env'] | path_join }}"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
         mode: '0600'

--- a/roles/agent/vars/main.yml
+++ b/roles/agent/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-agent_deploy_dir: "/home/{{ ansible_user }}/claude-agent"
+agent_deploy_dir: "{{ ['/home', ansible_user, 'claude-agent'] | path_join }}"
 agent_assignee: "kawajevo"
 agent_domain: "kawajevo.io37.ch"
 agent_certbot_email: "kawajevo@io37.ch"

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Create wallpapers directory.
   file:
-    path: "~{{ macbook_user.stdout }}/wallpapers"
+    path: "{{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}"
     state: directory
 
 - name: Synchronize wallpapers directory
   synchronize:
     src: wallpapers/
-    dest: "~{{ macbook_user.stdout }}/wallpapers/"
+    dest: "{{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}/"
     delete: yes
     recursive: yes
   when: ansible_connection == "local"
@@ -15,21 +15,21 @@
 - name: Copy wallpapers (for remote hosts)
   copy:
     src: "{{ item }}"
-    dest: ~/wallpapers
+    dest: "{{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}"
   with_fileglob:
     - wallpapers/*
   when: ansible_connection != "local"
 
 - name: Get list of wallpapers
   find:
-    paths: "/Users/{{ macbook_user.stdout }}/wallpapers"
+    paths: "{{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}"
     patterns: "*.png"
   register: wallpaper_files
 
 - name: Set first wallpaper as default
   shell: |
-    wallpaper_file=$(ls /Users/{{ macbook_user.stdout }}/wallpapers/*.png | sort | head -1 | xargs basename)
-    osascript -e 'tell application "System Events" to tell every desktop to set picture to POSIX file "/Users/{{ macbook_user.stdout }}/wallpapers/'$wallpaper_file'"'
+    wallpaper_file=$(ls {{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}/*.png | sort | head -1 | xargs basename)
+    osascript -e 'tell application "System Events" to tell every desktop to set picture to POSIX file "{{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}/'$wallpaper_file'"'
   when: wallpaper_files.files | length > 0
 
 - name: Set wallpapers for all spaces using wallpapers function

--- a/roles/diskspace/tasks/main.yml
+++ b/roles/diskspace/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Create diskspace directory
   file:
-    path: "{{ ansible_env.HOME }}/work/crons/diskspace"
+    path: "{{ [ansible_env.HOME, 'work', 'crons', 'diskspace'] | path_join }}"
     state: directory
     mode: "0755"
 
 - name: Copy diskspace scripts
   copy:
     src: "{{ item.src }}"
-    dest: "{{ ansible_env.HOME }}/work/crons/diskspace/{{ item.dest }}"
+    dest: "{{ [ansible_env.HOME, 'work', 'crons', 'diskspace', item.dest] | path_join }}"
     mode: "0755"
   with_items:
     - { src: "diskspace/guardian.sh", dest: "guardian.sh" }

--- a/roles/functions/tasks/ci.yml
+++ b/roles/functions/tasks/ci.yml
@@ -1,4 +1,4 @@
 - name: Copy ci functions
   copy:
     src: zsh/ci.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/ci.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'ci.zsh'] | path_join }}"

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -1,76 +1,76 @@
 ---
 - name: Create claude directory
   file:
-    path: "~{{ macbook_user.stdout }}/.claude"
+    path: "{{ ['~' + macbook_user.stdout, '.claude'] | path_join }}"
     state: directory
 
 - name: Create MEMORY/State directory for location persistence
   file:
-    path: "~{{ macbook_user.stdout }}/.claude/MEMORY/State"
+    path: "{{ ['~' + macbook_user.stdout, '.claude', 'MEMORY', 'State'] | path_join }}"
     state: directory
 
 - name: Create hubs directory for learning hub tracking
   file:
-    path: "~{{ macbook_user.stdout }}/.claude/hubs"
+    path: "{{ ['~' + macbook_user.stdout, '.claude', 'hubs'] | path_join }}"
     state: directory
 
 - name: Initialize hubs registry if not exists
   copy:
     content: '{"hubs":[]}'
-    dest: "~{{ macbook_user.stdout }}/.claude/hubs/registry.json"
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'hubs', 'registry.json'] | path_join }}"
     force: no
 
 - name: Copy CLAUDE.md
   copy:
     src: claude/config.md
-    dest: ~{{ macbook_user.stdout }}/.claude/CLAUDE.md
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'CLAUDE.md'] | path_join }}"
 
 - name: Copy ralph.md
   copy:
     src: claude/ralph.md
-    dest: ~{{ macbook_user.stdout }}/.claude/ralph.md
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'ralph.md'] | path_join }}"
 
 - name: Copy Claude settings
   copy:
     src: claude/settings.json
-    dest: ~{{ macbook_user.stdout }}/.claude/settings.json
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'settings.json'] | path_join }}"
 
 - name: Copy statusline script
   copy:
     src: claude/statusline.sh
-    dest: ~{{ macbook_user.stdout }}/.claude/statusline.sh
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'statusline.sh'] | path_join }}"
     mode: '0755'
 
 - name: Copy Claude skills
   copy:
     src: claude/skills/
-    dest: ~{{ macbook_user.stdout }}/.claude/skills/
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'skills'] | path_join }}/"
 
 - name: Copy Claude hooks
   copy:
     src: claude/hooks/
-    dest: ~{{ macbook_user.stdout }}/.claude/hooks/
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'hooks'] | path_join }}/"
     mode: '0755'
 
 - name: Copy Claude commands
   copy:
     src: claude/commands/
-    dest: ~{{ macbook_user.stdout }}/.claude/commands/
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'commands'] | path_join }}/"
 
 - name: Copy Claude agents
   copy:
     src: claude/agents/
-    dest: ~{{ macbook_user.stdout }}/.claude/agents/
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'agents'] | path_join }}/"
 
 - name: Create gemini directory
   file:
-    path: "~{{ macbook_user.stdout }}/.gemini"
+    path: "{{ ['~' + macbook_user.stdout, '.gemini'] | path_join }}"
     state: directory
 
 - name: Copy GEMINI.md
   copy:
     src: claude/config.md
-    dest: ~{{ macbook_user.stdout }}/.gemini/GEMINI.md
+    dest: "{{ ['~' + macbook_user.stdout, '.gemini', 'GEMINI.md'] | path_join }}"
 
 - name: Install typescript-language-server for LSP plugin
   community.general.npm:
@@ -100,13 +100,13 @@
 
 - name: Create Karabiner config directory
   file:
-    path: "{{ ansible_env.HOME }}/.config/karabiner"
+    path: "{{ [ansible_env.HOME, '.config', 'karabiner'] | path_join }}"
     state: directory
 
 - name: Copy Karabiner config
   copy:
     src: karabiner/karabiner.json
-    dest: "{{ ansible_env.HOME }}/.config/karabiner/karabiner.json"
+    dest: "{{ [ansible_env.HOME, '.config', 'karabiner', 'karabiner.json'] | path_join }}"
     force: yes
 
 - name: Install/update GSD (always runs for latest)

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -9,31 +9,31 @@
 - name: Copy darwin-specific zsh files
   ansible.builtin.copy:
     src: "{{ item }}"
-    dest: "~{{ macbook_user.stdout }}/.zsh/"
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh'] | path_join }}/"
   with_fileglob:
     - zsh/darwin/*.zsh
 
 - name: Copy MCP functions
   ansible.builtin.copy:
     src: zsh/mcp.zsh
-    dest: "~{{ macbook_user.stdout }}/.zsh/mcp.zsh"
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'mcp.zsh'] | path_join }}"
 
 - name: create empty tokens file only if one doesnt already exist
   ansible.builtin.copy:
     content: ""
-    dest: ~{{ macbook_user.stdout }}/.zsh/tokens.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'tokens.zsh'] | path_join }}"
     force: no
 
 - name: create trial file for new functions if one doesn't already exist
   ansible.builtin.copy:
     content: "tinker(){\n  echo try out new functions here, not in main file\n}"
-    dest: ~{{ macbook_user.stdout }}/.zsh/_trialling.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', '_trialling.zsh'] | path_join }}"
     force: no
 
 - name: copy js help file
   ansible.builtin.copy:
     src: help.js
-    dest: ~{{ macbook_user.stdout }}/.zsh/help.js
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'help.js'] | path_join }}"
 
 - name: Add ansible to path.
   lineinfile:
@@ -53,7 +53,7 @@
 - name: Copy dns functions
   ansible.builtin.copy:
     src: zsh/dns.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/dns.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'dns.zsh'] | path_join }}"
 
 - name: Makes zsh the cron shell
   ansible.builtin.cron:

--- a/roles/functions/tasks/debian.yml
+++ b/roles/functions/tasks/debian.yml
@@ -2,12 +2,12 @@
 - name: Copy debian
   copy:
     src: zsh/debian.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/debian.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'debian.zsh'] | path_join }}"
 
 - name: Copy dokku
   copy:
     src: zsh/dokku.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/dokku.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'dokku.zsh'] | path_join }}"
 
 - name: Register ansible location
   become: false
@@ -21,7 +21,7 @@
 
 - name: remove old provider.json
   file:
-    path: "~{{ macbook_user.stdout }}/provider.json"
+    path: "{{ ['~' + macbook_user.stdout, 'provider.json'] | path_join }}"
     state: absent
   become: true
   become_user: root
@@ -57,19 +57,19 @@
 - name: create empty tokens file only if one doesnt already exist
   copy:
     content: ""
-    dest: ~{{ macbook_user.stdout }}/.zsh/tokens.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'tokens.zsh'] | path_join }}"
     force: no
 
 - name: create trial file for new functions if one doesn't already exist
   copy:
     content: "tinker(){\n  echo try out new functions here, not in main file\n}"
-    dest: ~{{ macbook_user.stdout }}/.zsh/_trialling.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', '_trialling.zsh'] | path_join }}"
     force: no
 
 - name: copy js help file
   copy:
     src: help.js
-    dest: ~{{ macbook_user.stdout }}/.zsh/help.js
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'help.js'] | path_join }}"
 
 - name: Remove stale rails source line from zshrc
   lineinfile:

--- a/roles/functions/tasks/git.yml
+++ b/roles/functions/tasks/git.yml
@@ -1,53 +1,53 @@
 - name: Copy git functions
   copy:
     src: zsh/git.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/git.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'git.zsh'] | path_join }}"
 
 - name: Copy gitconfig
   template:
     src: gitconfig.j2
-    dest: ~{{ macbook_user.stdout }}/.gitconfig
+    dest: "{{ ['~' + macbook_user.stdout, '.gitconfig'] | path_join }}"
 
 - name: Create git directory
   file:
-    path: "~{{ macbook_user.stdout }}/.config/git"
+    path: "{{ ['~' + macbook_user.stdout, '.config', 'git'] | path_join }}"
     state: directory
 
 - name: Create git hooks directory
   file:
-    path: "~{{ macbook_user.stdout }}/.config/git/hooks"
+    path: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks'] | path_join }}"
     state: directory
 
 - name: Copy global pre-commit hook
   copy:
     src: git/pre-commit
-    dest: ~{{ macbook_user.stdout }}/.config/git/hooks/pre-commit
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'pre-commit'] | path_join }}"
     mode: a+x
 
 - name: Copy global post-receive hook
   copy:
     src: git/post-receive
-    dest: ~{{ macbook_user.stdout }}/.config/git/hooks/post-receive
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'post-receive'] | path_join }}"
     mode: a+x
 
 - name: Copy global post-checkout hook
   copy:
     src: git/post-checkout
-    dest: ~{{ macbook_user.stdout }}/.config/git/hooks/post-checkout
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'post-checkout'] | path_join }}"
     mode: a+x
 
 - name: Copy global commit-msg hook
   copy:
     src: git/commit-msg
-    dest: ~{{ macbook_user.stdout }}/.config/git/hooks/commit-msg
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'commit-msg'] | path_join }}"
     mode: a+x
 
 - name: Create blank template commit file
   copy:
     src: git/commit-msg-template
-    dest: ~{{ macbook_user.stdout }}/.config/git/commit-msg-template
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'commit-msg-template'] | path_join }}"
 
 - name: Create global gitignore
   copy:
     src: git/ignore
-    dest: ~{{ macbook_user.stdout }}/.config/git/ignore
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'ignore'] | path_join }}"

--- a/roles/functions/tasks/main.yml
+++ b/roles/functions/tasks/main.yml
@@ -1,17 +1,17 @@
 - name: Copy zshrc
   template:
     src: zshrc.j2
-    dest: ~{{ macbook_user.stdout }}/.zshrc
+    dest: "{{ ['~' + macbook_user.stdout, '.zshrc'] | path_join }}"
 
 - name: Create zsh directory
   file:
-    path: "~{{ macbook_user.stdout }}/.zsh"
+    path: "{{ ['~' + macbook_user.stdout, '.zsh'] | path_join }}"
     state: directory
 
 - name: Copy all zsh function files
   copy:
     src: "{{ item }}"
-    dest: "~{{ macbook_user.stdout }}/.zsh/"
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh'] | path_join }}/"
   with_fileglob:
     - zsh/*.zsh
 
@@ -29,29 +29,29 @@
 - name: Copy templates directory
   copy:
     src: templates/
-    dest: ~{{ macbook_user.stdout }}/.templates/
+    dest: "{{ ['~' + macbook_user.stdout, '.templates'] | path_join }}/"
 
 - name: Copy zsh gitignore
   copy:
     src: zsh/.gitignore
-    dest: ~{{ macbook_user.stdout }}/.zsh/.gitignore
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', '.gitignore'] | path_join }}"
 
 - name: Copy zshrc for informational purposes
   copy:
-    src: ~{{ macbook_user.stdout }}/.zshrc
-    dest: ~{{ macbook_user.stdout }}/.zsh/.zshrc
+    src: "{{ ['~' + macbook_user.stdout, '.zshrc'] | path_join }}"
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', '.zshrc'] | path_join }}"
   when: ansible_connection == "local"
 
 - name: Copy macfair file (this machine)
   template:
     src: zsh/macfair.zsh.j2
-    dest: ~{{ macbook_user.stdout }}/.zsh/macfair.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'macfair.zsh'] | path_join }}"
   when: hostvars['localhost']['hostname'].stdout == ansible_hostname
 
 - name: Copy macfair file (other machines)
   copy:
     src: zsh/macfair.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/macfair.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'macfair.zsh'] | path_join }}"
   when: hostvars['localhost']['hostname'].stdout != ansible_hostname
 
 - name: import ci.yml

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -73,7 +73,7 @@
 
 - name: Create directory for installed caskapps
   file:
-    path: "~{{ brew_user.stdout }}/Applications"
+    path: "{{ ['~' + brew_user.stdout, 'Applications'] | path_join }}"
     state: directory
     mode: 0775
 
@@ -105,7 +105,7 @@
 - name: Copy zshenv
   copy:
     src: zshenv
-    dest: ~{{ macbook_user.stdout }}/.zshenv
+    dest: "{{ ['~' + macbook_user.stdout, '.zshenv'] | path_join }}"
 
 - name: source zshenv so we get /usr/local/bin for npm
   shell: source ~/.zshenv
@@ -135,7 +135,7 @@
 
 - name: Check if Claude Code is installed
   stat:
-    path: "~{{ macbook_user.stdout }}/.local/bin/claude"
+    path: "{{ ['~' + macbook_user.stdout, '.local', 'bin', 'claude'] | path_join }}"
   register: claude_installed
 
 - name: Install Claude Code

--- a/roles/keepalive/tasks/main.yml
+++ b/roles/keepalive/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Create keepalive directory
   file:
-    path: "{{ ansible_env.HOME }}/work/crons/keepalive"
+    path: "{{ [ansible_env.HOME, 'work', 'crons', 'keepalive'] | path_join }}"
     state: directory
     mode: "0755"
 
 - name: Copy necessary files to keepalive directory
   copy:
     src: "{{ item.src }}"
-    dest: "{{ ansible_env.HOME }}/work/crons/keepalive/{{ item.dest }}"
+    dest: "{{ [ansible_env.HOME, 'work', 'crons', 'keepalive', item.dest] | path_join }}"
   with_items:
     - { src: "keepalive/index.mjs", dest: "index.mjs" }
     - { src: "keepalive/pages.mjs", dest: "pages.mjs" }
@@ -19,20 +19,20 @@
 - name: Initialize Node.js project
   command: npm init -y
   args:
-    chdir: "{{ ansible_env.HOME }}/work/crons/keepalive"
+    chdir: "{{ [ansible_env.HOME, 'work', 'crons', 'keepalive'] | path_join }}"
   register: npm_init
   changed_when: "'package.json' in npm_init.stdout"
 
 - name: Install Puppeteer
   command: npm install puppeteer
   args:
-    chdir: "{{ ansible_env.HOME }}/work/crons/keepalive"
+    chdir: "{{ [ansible_env.HOME, 'work', 'crons', 'keepalive'] | path_join }}"
   register: npm_install
   changed_when: "'node_modules' in npm_install.stdout"
 
 - name: Ensure index.mjs has execute permissions
   file:
-    path: "{{ ansible_env.HOME }}/work/crons/keepalive/index.mjs"
+    path: "{{ [ansible_env.HOME, 'work', 'crons', 'keepalive', 'index.mjs'] | path_join }}"
     mode: "0755"
 
 - name: Get ndoe location

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -1,62 +1,68 @@
 ---
 - name: Clone Rbenv
-  git: repo=https://github.com/rbenv/rbenv dest=~{{ macbook_user.stdout }}/.rbenv
+  ansible.builtin.git:
+    repo: https://github.com/rbenv/rbenv
+    dest: "{{ ['~' + macbook_user.stdout, '.rbenv'] | path_join }}"
 
 - name: Clone rbenv build
-  git: repo=https://github.com/rbenv/ruby-build dest=~{{ macbook_user.stdout }}/.rbenv/plugins/ruby-build
+  ansible.builtin.git:
+    repo: https://github.com/rbenv/ruby-build
+    dest: "{{ ['~' + macbook_user.stdout, '.rbenv', 'plugins', 'ruby-build'] | path_join }}"
 
 - name: Copy zsh rails
   copy:
     src: zsh/rails.zsh
-    dest: ~{{ macbook_user.stdout }}/.zsh/rails.zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'rails.zsh'] | path_join }}"
 
 - name: Add Rbenv to .zshrc
   lineinfile:
-    dest: "~{{ macbook_user.stdout }}/.zshrc"
+    dest: "{{ ['~' + macbook_user.stdout, '.zshrc'] | path_join }}"
     regexp: 'source \$HOME/.zsh/rails'
     line: 'source $HOME/.zsh/rails'
     state: present
 
 - name: Clone rbenv vars
-  git: repo=https://github.com/rbenv/rbenv-vars dest=~{{ macbook_user.stdout }}/.rbenv/plugins/rbenv-vars
+  ansible.builtin.git:
+    repo: https://github.com/rbenv/rbenv-vars
+    dest: "{{ ['~' + macbook_user.stdout, '.rbenv', 'plugins', 'rbenv-vars'] | path_join }}"
 
 - name: check ruby {{ ruby_version }} is installed for system
-  shell: "~{{ macbook_user.stdout }}/.rbenv/bin/rbenv versions | grep {{ruby_version}}"
+  shell: "{{ ['~' + macbook_user.stdout, '.rbenv', 'bin', 'rbenv'] | path_join }} versions | grep {{ ruby_version }}"
   register: ruby_installed
   changed_when: false
   ignore_errors: yes
   check_mode: no
 
 - name: rbenv install ruby
-  command: "~{{ macbook_user.stdout }}/.rbenv/bin/rbenv install --verbose {{ruby_version}}"
+  command: "{{ ['~' + macbook_user.stdout, '.rbenv', 'bin', 'rbenv'] | path_join }} install --verbose {{ ruby_version }}"
   when:
     - ruby_installed.rc != 0
   async: 3600
   poll: 10
 
 - name: check if current system ruby version is {{ ruby_version }}
-  shell: "~{{ macbook_user.stdout }}/.rbenv/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '{{ ruby_version }}'"
+  shell: "{{ ['~' + macbook_user.stdout, '.rbenv', 'bin', 'rbenv'] | path_join }} version | cut -d ' ' -f 1 | grep -Fx '{{ ruby_version }}'"
   register: current_ruby_selected
   changed_when: false
   ignore_errors: yes
   check_mode: no
 
 - name: rbenv set global ruby version and rehash
-  command: "~{{ macbook_user.stdout }}/.rbenv/bin/rbenv global {{ruby_version}} && rbenv rehash"
+  shell: "{{ ['~' + macbook_user.stdout, '.rbenv', 'bin', 'rbenv'] | path_join }} global {{ ruby_version }} && rbenv rehash"
   when:
     - current_ruby_selected.rc != 0
 
 - name: 'install bundler v2'
-  command: "~{{ macbook_user.stdout }}/.rbenv/shims/gem install bundler -v 2.2.23"
+  command: "{{ ['~' + macbook_user.stdout, '.rbenv', 'shims', 'gem'] | path_join }} install bundler -v 2.2.23"
 
 - name: 'install rails 7'
-  command: "~{{ macbook_user.stdout }}/.rbenv/shims/gem install rails"
+  command: "{{ ['~' + macbook_user.stdout, '.rbenv', 'shims', 'gem'] | path_join }} install rails"
 
 - name: 'install rails 6'
-  command: "~{{ macbook_user.stdout }}/.rbenv/shims/gem install rails -v 6.1.6.1"
+  command: "{{ ['~' + macbook_user.stdout, '.rbenv', 'shims', 'gem'] | path_join }} install rails -v 6.1.6.1"
 
 - name: 'rehash'
-  command: "~{{ macbook_user.stdout }}/.rbenv/bin/rbenv rehash"
+  command: "{{ ['~' + macbook_user.stdout, '.rbenv', 'bin', 'rbenv'] | path_join }} rehash"
 
 - name: import elastic search
   import_tasks: elastic.yml

--- a/roles/ruben/tasks/main.yml
+++ b/roles/ruben/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create ruben experimental namespace
   file:
-    path: "~{{ macbook_user.stdout }}/.claude/ruben/{{ item }}"
+    path: "{{ ['~' + macbook_user.stdout, '.claude', 'ruben', item] | path_join }}"
     state: directory
     mode: 0755
   loop:
@@ -14,20 +14,20 @@
 - name: Install diary command to main commands directory
   copy:
     src: commands/diary.md
-    dest: "~{{ macbook_user.stdout }}/.claude/commands/"
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'commands'] | path_join }}/"
     mode: 0644
   tags: ruben
 
 - name: Install ruben hooks
   copy:
     src: hooks/pre-compact-diary.sh
-    dest: "~{{ macbook_user.stdout }}/.claude/ruben/hooks/"
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'ruben', 'hooks'] | path_join }}/"
     mode: 0755
   tags: ruben
 
 - name: Install reflect command to main commands directory
   copy:
     src: commands/reflect.md
-    dest: "~{{ macbook_user.stdout }}/.claude/commands/reflect.md"
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'commands', 'reflect.md'] | path_join }}"
     mode: 0644
   tags: ruben

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Create conf.d directory
   file:
-    path: "~{{ macbook_user.stdout }}/.ssh/conf.d"
+    path: "{{ ['~' + macbook_user.stdout, '.ssh', 'conf.d'] | path_join }}"
     state: directory
     mode: "0700"
 
 - name: Find existing conf.d files
   find:
-    paths: "~{{ macbook_user.stdout }}/.ssh/conf.d"
+    paths: "{{ ['~' + macbook_user.stdout, '.ssh', 'conf.d'] | path_join }}"
     patterns: "*.conf"
   register: existing_conf_files
 
@@ -25,7 +25,7 @@
 - name: Copy conf.d files
   copy:
     src: "{{ item }}"
-    dest: "~{{ macbook_user.stdout }}/.ssh/conf.d/"
+    dest: "{{ ['~' + macbook_user.stdout, '.ssh', 'conf.d'] | path_join }}/"
     mode: "0600"
   with_fileglob:
     - ssh/conf.d/*.conf
@@ -33,7 +33,7 @@
 - name: Copy SSH config
   copy:
     src: ssh/config
-    dest: "~{{ macbook_user.stdout }}/.ssh/config"
+    dest: "{{ ['~' + macbook_user.stdout, '.ssh', 'config'] | path_join }}"
     mode: "0600"
     backup: yes
 

--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -2,18 +2,18 @@
 - name: Cloning oh-my-zsh
   git:
     repo: https://github.com/ohmyzsh/ohmyzsh
-    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.oh-my-zsh'] | path_join }}"
     update: no
 
 - name: Copy zsh theme
   copy:
     src: cerico.zsh-theme
-    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh/themes/cerico.zsh-theme
+    dest: "{{ ['~' + macbook_user.stdout, '.oh-my-zsh', 'themes', 'cerico.zsh-theme'] | path_join }}"
 
 - name: Copy zsh theme ii
   copy:
     src: cerico-w-user.zsh-theme
-    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh/themes/cerico-w-user.zsh-theme
+    dest: "{{ ['~' + macbook_user.stdout, '.oh-my-zsh', 'themes', 'cerico-w-user.zsh-theme'] | path_join }}"
 
 - name: change user shell to zsh
   become: true
@@ -24,7 +24,7 @@
 
 - name: register iterm location
   stat:
-    path: ~{{ macbook_user.stdout }}/Library/Application Support/iTerm2
+    path: "{{ ['~' + macbook_user.stdout, 'Library', 'Application Support', 'iTerm2'] | path_join }}"
   register: iterm_path
 
 - name: Create iterm preferences by opening
@@ -34,17 +34,17 @@
 - name: copy iterm profiles
   template:
     src: iterm.json.j2
-    dest: ~{{ macbook_user.stdout }}/Library/Application Support/iTerm2/DynamicProfiles/iterm.json
+    dest: "{{ ['~' + macbook_user.stdout, 'Library', 'Application Support', 'iTerm2', 'DynamicProfiles', 'iterm.json'] | path_join }}"
   when: iterm_path.stat.exists
 
 - name: Create pnpm-audit directory
   file:
-    path: "{{ ansible_env.HOME }}/work/crons/pnpm-audit"
+    path: "{{ [ansible_env.HOME, 'work', 'crons', 'pnpm-audit'] | path_join }}"
     state: directory
     mode: "0755"
 
 - name: Copy pnpm-audit script
   copy:
     src: pnpm-audit/daily-pnpm-audit.sh
-    dest: "{{ ansible_env.HOME }}/work/crons/pnpm-audit/daily-pnpm-audit.sh"
+    dest: "{{ [ansible_env.HOME, 'work', 'crons', 'pnpm-audit', 'daily-pnpm-audit.sh'] | path_join }}"
     mode: "0755"

--- a/roles/terminal/tasks/debian.yml
+++ b/roles/terminal/tasks/debian.yml
@@ -9,18 +9,18 @@
 - name: Cloning oh-my-zsh
   git:
     repo: https://github.com/ohmyzsh/ohmyzsh
-    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh
+    dest: "{{ ['~' + macbook_user.stdout, '.oh-my-zsh'] | path_join }}"
     update: no
 
 - name: Copy zsh theme
   copy:
     src: cerico.zsh-theme
-    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh/themes/cerico.zsh-theme
+    dest: "{{ ['~' + macbook_user.stdout, '.oh-my-zsh', 'themes', 'cerico.zsh-theme'] | path_join }}"
 
 - name: Copy zsh theme ii
   copy:
     src: cerico-w-user.zsh-theme
-    dest: ~{{ macbook_user.stdout }}/.oh-my-zsh/themes/cerico-w-user.zsh-theme
+    dest: "{{ ['~' + macbook_user.stdout, '.oh-my-zsh', 'themes', 'cerico-w-user.zsh-theme'] | path_join }}"
 
 - name: change user shell to zsh
   become: true

--- a/roles/version/tasks/main.yml
+++ b/roles/version/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
 - name: Create macfair if directory only if doesnt exist
   file:
-    path: "~{{ macbook_user.stdout }}/.macfair"
+    path: "{{ ['~' + macbook_user.stdout, '.macfair'] | path_join }}"
     state: directory
     force: no
 
 - name: create empty version file only if doesnt already exist
   copy:
     content: ""
-    dest: ~{{ macbook_user.stdout }}/.macfair/version
+    dest: "{{ ['~' + macbook_user.stdout, '.macfair', 'version'] | path_join }}"
     force: no
 
 - name: store macfair location
   copy:
     content: "{{ playbook_dir }}"
-    dest: ~{{ macbook_user.stdout }}/.macfair/location
+    dest: "{{ ['~' + macbook_user.stdout, '.macfair', 'location'] | path_join }}"
 
 - name: add version to file
   lineinfile:
-    path: "~{{ macbook_user.stdout }}/.macfair/version"
+    path: "{{ ['~' + macbook_user.stdout, '.macfair', 'version'] | path_join }}"
     line: "{{ parent_role_name }}: {{ hostvars['localhost']['macfair_version'].stdout[1:-1] }}"
     regexp: '{{ parent_role_name }}'
     insertbefore: BOF

--- a/roles/vscode/tasks/main.yml
+++ b/roles/vscode/tasks/main.yml
@@ -38,38 +38,38 @@
 - name: copy vscode profile darwin
   copy:
     src: vscode.json
-    dest: ~{{ macbook_user.stdout }}/Library/Application Support/Code/User/settings.json
+    dest: "{{ ['~' + macbook_user.stdout, 'Library', 'Application Support', 'Code', 'User', 'settings.json'] | path_join }}"
   when: ansible_os_family == "Darwin"
 
 - name: copy vscode profile debian
   copy:
     src: vscode.json
-    dest: ~{{ macbook_user.stdout }}/.config/Code/User/settings.json
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'Code', 'User', 'settings.json'] | path_join }}"
   when: ansible_os_family == "Debian"
 
 - name: Create snippets directory
   file:
-    path: ~{{ macbook_user.stdout }}/Library/Application Support/Code/User/snippets
+    path: "{{ ['~' + macbook_user.stdout, 'Library', 'Application Support', 'Code', 'User', 'snippets'] | path_join }}"
     state: directory
   when: ansible_os_family == "Darwin"
 
 - name: Copy snippets
   copy:
     src: "{{ item }}"
-    dest: ~{{ macbook_user.stdout }}/Library/Application Support/Code/User/snippets
+    dest: "{{ ['~' + macbook_user.stdout, 'Library', 'Application Support', 'Code', 'User', 'snippets'] | path_join }}"
   with_fileglob:
     - snippets/*
   when: ansible_os_family == "Darwin"
 
 - name: Create themes directory
   file:
-    path: ~{{ macbook_user.stdout }}/.vscode/themes
+    path: "{{ ['~' + macbook_user.stdout, '.vscode', 'themes'] | path_join }}"
     state: directory
 
 - name: Copy themes
   copy:
     src: "{{ item }}"
-    dest: ~{{ macbook_user.stdout }}/.vscode/themes
+    dest: "{{ ['~' + macbook_user.stdout, '.vscode', 'themes'] | path_join }}"
   with_fileglob:
     - themes/*
 

--- a/thiscomputer.yml
+++ b/thiscomputer.yml
@@ -16,28 +16,28 @@
     - name: Create main vars yml for localhost
       template:
         src: vars/localhost.yml.j2
-        dest: "{{ playbook_dir }}/host_vars/localhost.yml"
+        dest: "{{ [playbook_dir, 'host_vars', 'localhost.yml'] | path_join }}"
         force: false
 
     - name: Create vars folder for this hostname
       file:
-        path: "{{ playbook_dir }}/host_vars/{{ target }}.localhost"
+        path: "{{ [playbook_dir, 'host_vars', target + '.localhost'] | path_join }}"
         state: directory
 
     - name: Create main vars yml for target
       template:
         src: vars/this.yml.j2
-        dest: "{{ playbook_dir }}/host_vars/{{ target }}.localhost/vars.yml"
+        dest: "{{ [playbook_dir, 'host_vars', target + '.localhost', 'vars.yml'] | path_join }}"
 
     - name: Create main vars yml for target
       template:
         src: vars/hosts.j2
-        dest: "{{ playbook_dir }}/hosts"
+        dest: "{{ [playbook_dir, 'hosts'] | path_join }}"
         force: false
 
     - name: Add target to inventory file when debian.
       lineinfile:
-        path: "{{ playbook_dir }}/hosts"
+        path: "{{ [playbook_dir, 'hosts'] | path_join }}"
         line: "{{ target }}.localhost"
         regexp: '.localhost'
         insertafter: "debian"
@@ -45,7 +45,7 @@
 
     - name: Add target to inventory file when darwin.
       lineinfile:
-        path: "{{ playbook_dir }}/hosts"
+        path: "{{ [playbook_dir, 'hosts'] | path_join }}"
         line: "{{ target }}.localhost"
         regexp: '.localhost'
         insertafter: "macbook"


### PR DESCRIPTION
use path_join filter for all Ansible paths

- Replace string concatenation with path_join filter across all roles and playbooks
- Fix typo in addpackage.yml (lineinfile.lineinfile → lineinfile)
- Modernize rails role git tasks from inline to YAML format
- Add make verify target for syntax-checking all playbooks
- Add playbook syntax-check step to CI workflow
- Add makefiles/claude.mk for verify targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated playbook syntax validation to CI and a corresponding verification task to run local checks.

* **Improvements**
  * Standardized path construction across the automation to improve cross-platform reliability and correctness.
  * Added cleanup and robustness improvements for SSH and configuration file deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->