### PR TITLE
tmux neovim

### DIFF
--- a/files/claude/skills/speak/skill.md
+++ b/files/claude/skills/speak/skill.md
@@ -30,6 +30,7 @@ IMPORTANT:
 - For long responses (500+ words), split into multiple speak calls
 - The permission pattern `Bash(/usr/local/bin/speak *)` auto-approves these calls
 - Works in both normal mode and plan mode (no Write tool needed)
+- When speaking and your next action needs permission, speak what you are about to do before the tool call so the user knows to check the screen
 
 ## Voice Options
 

--- a/files/nvim/init.lua
+++ b/files/nvim/init.lua
@@ -1,0 +1,33 @@
+vim.g.mapleader = " "
+
+vim.opt.number = true
+vim.opt.relativenumber = true
+vim.opt.signcolumn = "yes"
+vim.opt.cursorline = true
+
+vim.opt.tabstop = 2
+vim.opt.shiftwidth = 2
+vim.opt.expandtab = true
+vim.opt.smartindent = true
+
+vim.opt.ignorecase = true
+vim.opt.smartcase = true
+
+vim.opt.splitbelow = true
+vim.opt.splitright = true
+
+vim.opt.termguicolors = true
+vim.opt.scrolloff = 8
+
+vim.opt.clipboard = "unnamedplus"
+
+vim.opt.undofile = true
+
+vim.opt.background = "dark"
+vim.cmd.colorscheme("gruvbox")
+vim.api.nvim_set_hl(0, "Normal", { bg = "NONE" })
+vim.api.nvim_set_hl(0, "NormalFloat", { bg = "NONE" })
+
+vim.keymap.set("n", "<leader>w", "<cmd>w<cr>")
+vim.keymap.set("n", "<leader>q", "<cmd>q<cr>")
+vim.keymap.set("n", "<Esc>", "<cmd>nohlsearch<cr>")

--- a/files/tmux.conf
+++ b/files/tmux.conf
@@ -1,0 +1,43 @@
+# Prefix
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# Neovim-friendly
+set -sg escape-time 10
+set -g focus-events on
+
+# True color
+set -g default-terminal "tmux-256color"
+set -sa terminal-overrides ",xterm-256color:RGB"
+
+# Mouse
+set -g mouse on
+
+# Vi copy mode
+setw -g mode-keys vi
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
+
+# Splits inherit current path
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+# Pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Index from 1
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Status bar
+set -g status-style "bg=default,fg=white"
+set -g status-left "#[fg=blue,bold] #S "
+set -g status-right "#[fg=white,dim] %H:%M "
+set -g status-left-length 20

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -5,6 +5,23 @@ unalias claude clauden claudev claudevn claudep claudevp claudex claudepod discu
 
 CLAUDE_LOCKFILE=".claude-session.lock"
 
+_claude_tmux() {
+  local session="${${PWD##*/}//[.:]/_}"
+  if tmux has-session -t "$session" 2>/dev/null; then
+    tmux attach -t "$session"
+    return
+  fi
+  tmux new-session -d -s "$session" -c "$PWD"
+  tmux split-window -h -t "$session" -p 30
+  tmux split-window -v -t "$session"
+  tmux send-keys -t "$session:1.2" "clear" Enter
+  tmux send-keys -t "$session:1.3" "clear" Enter
+  tmux select-pane -t "$session:1.1"
+  local cmd=$(printf '%q ' "$@")
+  tmux send-keys -t "$session:1.1" "$cmd; tmux kill-session -t $session" Enter
+  tmux attach -t "$session"
+}
+
 _claude_lock() {
   if [[ -f "$CLAUDE_LOCKFILE" ]]; then
     local lock_pid=$(cat "$CLAUDE_LOCKFILE" 2>/dev/null)
@@ -39,6 +56,13 @@ _claude_maybe_gsd() {
 }
 
 claude() {
+  if [[ -z "$TMUX" ]]; then
+    local -a args=(command claude --permission-mode plan)
+    [[ $# -eq 0 ]] && [[ -f .planning/STATE.md ]] && args+=(go)
+    [[ $# -gt 0 ]] && args+=("$@")
+    _claude_tmux "${args[@]}"
+    return
+  fi
   [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan; return; }
   _claude_run --permission-mode plan "$@"
 }
@@ -47,12 +71,12 @@ clauden() {
   _claude_run "$@"
 }
 claudev() {
-  local voice='Always speak responses aloud using the /speak skill. Every response should be voiced via Kokoro TTS.'
+  local voice='Always speak responses aloud using the /speak skill. Every response should be voiced via Kokoro TTS. Before any tool call that needs permission, speak what you are about to do so the user knows to check the screen.'
   [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan --append-system-prompt "$voice"; return; }
   _claude_run --permission-mode plan --append-system-prompt "$voice" "$@"
 }
 claudevn() {
-  local voice='Always speak responses aloud using the /speak skill. Every response should be voiced via Kokoro TTS.'
+  local voice='Always speak responses aloud using the /speak skill. Every response should be voiced via Kokoro TTS. Before any tool call that needs permission, speak what you are about to do so the user knows to check the screen.'
   [[ $# -eq 0 ]] && { _claude_maybe_gsd --append-system-prompt "$voice"; return; }
   _claude_run --append-system-prompt "$voice" "$@"
 }
@@ -68,9 +92,42 @@ claudex() {
 }
 
 discuss() {
-  local voice='Always speak every response aloud using the /speak skill (Kokoro TTS on port 8880, then afplay). Skip code blocks in the spoken version - focus on reasoning, strategy, and discussion. The user can see the full text on screen, so the spoken part should be conversational.'
+  local voice='Always speak every response aloud using the /speak skill (Kokoro TTS on port 8880, then afplay). Skip code blocks in the spoken version - focus on reasoning, strategy, and discussion. The user can see the full text on screen, so the spoken part should be conversational. Before any tool call that needs permission, speak what you are about to do so the user knows to check the screen.'
+  if [[ -z "$TMUX" ]]; then
+    local -a args=(command claude --permission-mode plan --append-system-prompt "$voice")
+    [[ $# -eq 0 ]] && [[ -f .planning/STATE.md ]] && args+=(go)
+    [[ $# -gt 0 ]] && args+=("$@")
+    _claude_tmux "${args[@]}"
+    return
+  fi
   [[ $# -eq 0 ]] && { _claude_maybe_gsd --permission-mode plan --append-system-prompt "$voice"; return; }
   _claude_run --permission-mode plan --append-system-prompt "$voice" "$@"
+}
+
+vps() {
+  [[ -z "$1" ]] && { echo "Usage: vps <host>"; return 1; }
+  local host="$1" session="vps_${1//[.:]/_}"
+  shift
+  if [[ -n "$TMUX" ]]; then
+    ssh "$host"
+    return
+  fi
+  if tmux has-session -t "$session" 2>/dev/null; then
+    tmux attach -t "$session"
+    return
+  fi
+  local macfair="$HOME/macfair"
+  tmux new-session -d -s "$session" -c "$macfair"
+  tmux split-window -h -t "$session" -p 30 -c "$macfair"
+  tmux split-window -v -t "$session" -c "$macfair"
+  tmux send-keys -t "$session:1.2" "clear && ssh $(printf '%q' "$host")" Enter
+  tmux send-keys -t "$session:1.3" "clear" Enter
+  tmux select-pane -t "$session:1.1"
+  local -a args=(command claude --permission-mode plan)
+  [[ $# -gt 0 ]] && args+=("$@")
+  local cmd=$(printf '%q ' "${args[@]}")
+  tmux send-keys -t "$session:1.1" "$cmd; tmux kill-session -t $session" Enter
+  tmux attach -t "$session"
 }
 
 claudewright() {

--- a/files/zsh/neovim.zsh
+++ b/files/zsh/neovim.zsh
@@ -1,0 +1,3 @@
+alias vi=nvim
+alias vim=nvim
+export EDITOR=nvim

--- a/files/zsh/tmux.zsh
+++ b/files/zsh/tmux.zsh
@@ -1,0 +1,35 @@
+# tmux utilities
+
+_tmux_layout() {
+  local session="$1" layout="${2:-dev}"
+  case "$layout" in
+    dev)
+      tmux split-window -h -t "$session" -p 30
+      tmux split-window -v -t "$session"
+      tmux select-pane -t "$session:1.1"
+      ;;
+    half)
+      tmux split-window -h -t "$session" -p 50
+      tmux select-pane -t "$session:1.1"
+      ;;
+    single) ;;
+  esac
+}
+
+tx() {
+  local name="${${1:-${PWD##*/}}//[.:]/_}" layout="${2:-dev}"
+  if tmux has-session -t "$name" 2>/dev/null; then
+    tmux attach -t "$name"
+    return
+  fi
+  tmux new-session -d -s "$name" -c "$PWD"
+  _tmux_layout "$name" "$layout"
+  tmux attach -t "$name"
+}
+
+tls() { tmux list-sessions 2>/dev/null || echo "No sessions"; }
+
+tkill() {
+  [[ -z "$1" ]] && { echo "Usage: tkill <session>"; return 1; }
+  tmux kill-session -t "$1" 2>/dev/null && echo "Killed $1" || echo "No session: $1"
+}

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -13,6 +13,28 @@
     mode: '0755'
   become: true
 
+- name: Copy tmux config
+  ansible.builtin.copy:
+    src: tmux.conf
+    dest: "{{ ['~' + macbook_user.stdout, '.tmux.conf'] | path_join }}"
+
+- name: Create neovim config directory
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, '.config', 'nvim'] | path_join }}"
+    state: directory
+
+- name: Copy neovim config
+  ansible.builtin.copy:
+    src: nvim/init.lua
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'nvim', 'init.lua'] | path_join }}"
+
+- name: Install gruvbox colorscheme for neovim
+  ansible.builtin.git:
+    repo: https://github.com/morhetz/gruvbox.git
+    dest: "{{ ['~' + macbook_user.stdout, '.local', 'share', 'nvim', 'site', 'pack', 'colors', 'start', 'gruvbox'] | path_join }}"
+    version: master
+    depth: 1
+
 - name: Copy darwin-specific zsh files
   ansible.builtin.copy:
     src: "{{ item }}"

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -37,6 +37,7 @@
         "nmap",
         "htop",
         "tmux",
+        "neovim",
         "postgresql",
         "redis",
         "lima",


### PR DESCRIPTION
add tmux integration, vps workflow, and neovim setup

- Auto-launch tmux with 70/30 layout when running claude or discuss outside tmux
- Kill tmux session on Claude exit for clean teardown
- Clear right panes on startup to suppress chpwd noise
- Add vps function: Claude + SSH in tmux layout, auto-teardown
- Voice mode: speak before permission prompts so user knows to check screen
- Add tmux.conf with Ctrl+A prefix, vi copy mode, neovim-friendly settings
- Add tmux.zsh utilities: tx, tls, tkill for standalone session management
- Alias vi/vim to nvim, set EDITOR=nvim
- Add minimal init.lua: line numbers, clipboard, sensible defaults
- Deploy tmux.conf and nvim config via Ansible
- Add neovim to brew install list
- Sanitize tmux session names: replace dots and colons with underscores

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal multiplexer and Neovim configurations and convenient shell utilities for creating/managing sessions, including a VPS workflow.

* **New Features**
  * Claude now announces intended actions before requesting permission.

* **Documentation**
  * Updated Claude guidance to highlight pre-action permission checks.

* **Chores**
  * Added Neovim to the default macOS installation and included provisioning steps for editor and terminal setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->