### PR TITLE
fix/claude session management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Syntax-check ZSH files
+        run: |
+          failed=0
+          for f in files/zsh/*.zsh files/bin/*; do
+            [[ -f "$f" ]] || continue
+            if ! zsh -n "$f" 2>&1; then
+              echo "FAIL: $f"
+              failed=1
+            fi
+          done
+          exit $failed
+        shell: zsh {0}
+
+      - name: Syntax-check shell scripts
+        run: |
+          failed=0
+          while IFS= read -r -d '' f; do
+            if ! bash -n "$f" 2>&1; then
+              echo "FAIL: $f"
+              failed=1
+            fi
+          done < <(find files -name '*.sh' -type f -print0)
+          exit $failed
+
+      - name: Validate JSON files
+        run: |
+          failed=0
+          while IFS= read -r -d '' f; do
+            if ! python3 -m json.tool "$f" > /dev/null 2>&1; then
+              echo "FAIL: $f"
+              python3 -m json.tool "$f" 2>&1 || true
+              failed=1
+            fi
+          done < <(find files -name '*.json' -type f -print0)
+          exit $failed
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/files/claude/commands/commit.md
+++ b/files/claude/commands/commit.md
@@ -43,3 +43,34 @@
 
 6. **After commit, run review:**
    Then invoke `/review 2` to get feedback before pushing.
+
+## Post-commit waypoints
+
+Run these silently after review. Skip any that have nothing to report.
+
+### 7. File undecided permissions
+Check if any tool calls during this session required user permission (the user was prompted to allow/deny). Compare tools used against the allow patterns in `~/.claude/settings.json`. For any tool call that doesn't match an allow pattern and isn't already listed in `~/.claude/permissions.md`:
+- Read `~/.claude/permissions.md`
+- Append new entries under the `## Undecided` section with format: `- \`ToolName(pattern)\` — context of what it was used for (YYYY-MM-DD)`
+- Write the updated file
+
+### 8. Memory capture
+Reflect on the session: did we discover a repeatable pattern, a gotcha, a convention, or a debugging insight worth preserving? If yes:
+- Read the relevant memory file in the project's `.claude/` memory directory (or `~/.claude/` for cross-project learnings)
+- Append or update with the new insight
+- Keep entries concise and actionable
+- If nothing worth capturing, skip silently
+
+### 9. CLAUDE.md drift check
+**Only if the project has a CLAUDE.md.** Many projects don't — skip silently if absent. Do not create one.
+Compare what we actually did in this session against the project's CLAUDE.md instructions. If we introduced patterns that contradict or extend what's documented (e.g. switched libraries, changed conventions, added new patterns):
+- Flag the specific drift to the user
+- Suggest the update to CLAUDE.md
+- Do not auto-update — let the user decide
+
+### 10. TODO harvest
+**Only if the project already has a TODO.md.** Skip silently if absent. Do not create one.
+Scan the session for loose ends: things we said we'd do later, tests we skipped, known issues we deferred. If any exist:
+- Read the project's `TODO.md`
+- Append new items that aren't already listed
+- Format: `- [ ] Description (from session YYYY-MM-DD)`

--- a/files/claude/permissions.md
+++ b/files/claude/permissions.md
@@ -1,0 +1,48 @@
+# Tool Permissions
+
+Cross-repo working document. Updated by commit command, reviewed via `/permissions` skill.
+Source of truth for allow/deny rules remains `files/claude/settings.json` in antwerp.
+
+## Allow
+
+Auto-approved tool calls. These are in settings.json and run without prompting.
+
+- `mcp__playwright__browser_*` — browser automation (navigate, click, type, screenshot, etc.)
+- `WebFetch(domain:*)` — fetch any web domain
+- `WebSearch` — web search
+- `Read(*)` — read any file
+- `Glob(*)` — find files by pattern
+- `Grep(*)` — search file contents
+- `Skill(skill:review-pr)` — PR review skill
+- `Bash(pnpm *)` — pnpm commands (list, build, dev, test, lint, outdated, why, remove, install, add, prisma)
+- `Bash(git *)` — all git commands
+- `Bash(gh issue *)` — GitHub issues
+- `Bash(gh pr view/list/checks *)` — GitHub PR read operations
+- `Bash(gh api --method GET *)` — GitHub API read-only
+- `Bash(semgrep *)` — security scanning
+- `Bash(nightshift:*)` — nightshift agent commands
+- `Bash(/usr/local/bin/speak *)` — TTS voice output
+
+## Deny
+
+Blocked tool calls. Always prompt regardless of allow rules.
+
+- `Bash(git push *)` — pushing code requires explicit approval
+- `Bash(gh pr create *)` — PR creation requires explicit approval
+- `Read(**/.env*)` — environment files with secrets
+- `Read(**/.npmrc)` — npm auth config
+- `Read(**/tokens.zsh)` — token files
+- `Read(**/keys.zsh)` — key files
+- `Read(**/*.pem)` — certificates
+- `Read(**/.ssh/*)` — SSH keys
+
+## Supervised
+
+Good tool calls we actively want to approve each time. Conscious decision to keep prompting.
+
+
+## Undecided
+
+Tool calls that prompted during sessions but haven't been categorised yet.
+Populated automatically by the commit command. Review with `/permissions`.
+

--- a/files/claude/skills/permissions/SKILL.md
+++ b/files/claude/skills/permissions/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: permissions
+description: Review undecided tool permissions and promote them to Allow or Supervised. Run when prompted by Slack alert or when you want to triage tool permissions.
+user_invocable: true
+---
+
+# Permissions Review
+
+Review and triage undecided tool call permissions.
+
+## When to Use
+
+- After receiving a Slack alert about undecided permissions
+- When you want to review what tools Claude has been prompted for
+- Periodically to keep the permissions list tidy
+
+## Instructions
+
+1. Read `~/.claude/permissions.md`
+2. Check the **Undecided** section. If empty, say so and exit.
+3. For each undecided entry, present it to the user with context:
+   - What the tool does
+   - Whether it's safe to auto-allow
+   - Whether supervision adds value
+4. Ask the user for each: **Allow**, **Supervised**, or **Skip** (leave undecided for now)
+5. For items marked **Allow**:
+   - Move to the Allow section in `~/.claude/permissions.md`
+   - Read `~/macfair/files/claude/settings.json`
+   - Add the appropriate pattern to `permissions.allow` array
+   - Write the updated settings.json
+   - Tell the user to run `make claude` to deploy
+6. For items marked **Supervised**:
+   - Move to the Supervised section in `~/.claude/permissions.md` with a note on why
+7. For items marked **Skip**:
+   - Leave in Undecided
+8. Write the updated `~/.claude/permissions.md`
+
+## Important
+
+- The source of truth for allow rules is `~/macfair/files/claude/settings.json`
+- The permissions.md file is a working document, not config
+- Never edit deployed files at `~/.claude/settings.json` directly
+- Batch the AskUserQuestion calls where possible to reduce interruptions

--- a/files/claude/skills/speak/skill.md
+++ b/files/claude/skills/speak/skill.md
@@ -31,6 +31,7 @@ IMPORTANT:
 - The permission pattern `Bash(/usr/local/bin/speak *)` auto-approves these calls
 - Works in both normal mode and plan mode (no Write tool needed)
 - When speaking and your next action needs permission, speak what you are about to do before the tool call so the user knows to check the screen
+- When using AskUserQuestion or any tool that requires user permission/input, speak "Response required" before the tool call so the user knows to check the screen even when away from the terminal
 
 ## Voice Options
 

--- a/files/claude/statusline.sh
+++ b/files/claude/statusline.sh
@@ -165,9 +165,23 @@ if [[ -n "${BRANCH:-}" ]]; then
     OUTPUT="$OUTPUT | $BRANCH_DISPLAY"
 fi
 
-# Add disk free
+# Add disk free (color by available space)
 if [[ -n "${DISK_FREE:-}" ]]; then
-    OUTPUT="$OUTPUT | ${DIM}${DISK_FREE}${RESET}"
+    DISK_COLOR="$GREEN"
+    DISK_VAL="${DISK_FREE//[^0-9.]/}"
+    if [[ "$DISK_FREE" == *Gi* || "$DISK_FREE" == *G* ]]; then
+        DISK_INT=${DISK_VAL%.*}
+        if [[ "$DISK_INT" -lt 2 ]]; then
+            DISK_COLOR="$RED"
+        elif [[ "$DISK_INT" -lt 5 ]]; then
+            DISK_COLOR="$ORANGE"
+        elif [[ "$DISK_INT" -lt 10 ]]; then
+            DISK_COLOR="$YELLOW"
+        fi
+    elif [[ "$DISK_FREE" == *Mi* || "$DISK_FREE" == *M* ]]; then
+        DISK_COLOR="$RED"
+    fi
+    OUTPUT="$OUTPUT | ${DISK_COLOR}${DISK_FREE}${RESET}"
 fi
 
 # Add memory pressure (green >=50%, yellow 30-50%, red <30%)

--- a/files/diskspace/guardian.sh
+++ b/files/diskspace/guardian.sh
@@ -1,23 +1,74 @@
 #!/bin/bash
 # Cleans caches when disk space drops below threshold
 MIN_FREE_GB=15
+BALLAST_SIZE_GB=5
+BALLAST_RECREATE_GB=10
+CRITICAL_GB=2
 FREE_GB=$(df -g / | awk 'NR==2 {print $4}')
 LOG=~/.local/share/diskspace.log
-
-[[ $FREE_GB -ge $MIN_FREE_GB ]] && exit 0
+BALLAST=~/.local/share/diskspace_ballast
 
 mkdir -p ~/.local/share
 
+# Always run: clean ephemeral data regardless of disk pressure
+find ~/Library/Application\ Support/ru.starmel.OpenSuperWhisper/recordings -name "*.wav" -mmin +60 -delete 2>/dev/null
+
+# Critical: delete ballast immediately for breathing room
+if [[ $FREE_GB -lt $CRITICAL_GB && -f "$BALLAST" ]]; then
+    rm -f "$BALLAST"
+    echo "$(date '+%Y-%m-%d %H:%M'): CRITICAL (${FREE_GB}GB). Deleted ballast file." >> "$LOG"
+    FREE_GB=$(df -g / | awk 'NR==2 {print $4}')
+fi
+
+# Ensure ballast exists when space is reasonable
+if [[ $FREE_GB -ge $BALLAST_RECREATE_GB && ! -f "$BALLAST" ]]; then
+    if mkfile ${BALLAST_SIZE_GB}g "$BALLAST" 2>/dev/null; then
+        echo "$(date '+%Y-%m-%d %H:%M'): Created ${BALLAST_SIZE_GB}GB ballast file." >> "$LOG"
+        FREE_GB=$(df -g / | awk 'NR==2 {print $4}')
+    else
+        echo "$(date '+%Y-%m-%d %H:%M'): Failed to create ballast file." >> "$LOG"
+    fi
+fi
+
+[[ $FREE_GB -ge $MIN_FREE_GB ]] && exit 0
+
 echo "$(date '+%Y-%m-%d %H:%M'): Low disk (${FREE_GB}GB). Cleaning..." >> "$LOG"
 
+# Package managers
 rm -rf ~/.cache/uv ~/Library/Caches/pip 2>/dev/null
 npm cache clean --force 2>/dev/null
-rm -rf ~/Library/Caches/lima ~/Library/Caches/com.todesktop* 2>/dev/null
-podman system prune -af 2>/dev/null
-rm -rf ~/Library/Caches/sh.tight.voice-code 2>/dev/null
+pnpm store prune 2>/dev/null
 brew cleanup --prune=all 2>/dev/null
 go clean -cache 2>/dev/null
-pnpm store prune 2>/dev/null
+
+# Containers
+rm -rf ~/Library/Caches/lima 2>/dev/null
+podman system prune -af 2>/dev/null
+
+# Large cache targets
+rm -rf ~/.cache/puppeteer 2>/dev/null
+rm -rf ~/.cache/huggingface 2>/dev/null
+rm -rf ~/.cache/prisma 2>/dev/null
+
+# Browser caches
+rm -rf ~/Library/Caches/Vivaldi 2>/dev/null
+rm -rf ~/Library/Caches/Arc 2>/dev/null
+rm -rf ~/Library/Caches/com.kagi.kagimacOS 2>/dev/null
+rm -rf ~/Library/Caches/org.mozilla.firefox 2>/dev/null
+
+# App caches
+rm -rf ~/Library/Caches/com.todesktop* 2>/dev/null
+rm -rf ~/Library/Caches/sh.tight.voice-code 2>/dev/null
+rm -rf ~/Library/Caches/node-gyp 2>/dev/null
+rm -rf ~/Library/Caches/@lineardesktop-updater 2>/dev/null
+rm -rf ~/Library/Caches/com.steipete.repobar 2>/dev/null
+
+# Unused apps
+rm -rf ~/Library/Application\ Support/Wispr\ Flow 2>/dev/null
+rm -rf ~/Library/Caches/com.wispr.flow 2>/dev/null
+
+# Time Machine local snapshots
+tmutil thinlocalsnapshots / 10000000000 4 2>/dev/null
 
 NEW_FREE=$(df -g / | awk 'NR==2 {print $4}')
 echo "$(date '+%Y-%m-%d %H:%M'): Cleaned. Now ${NEW_FREE}GB free." >> "$LOG"

--- a/files/permissions-alert/check_permissions.sh
+++ b/files/permissions-alert/check_permissions.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+SLACK_WEBHOOK="${AUDIT_SLACK_WEBHOOK:?AUDIT_SLACK_WEBHOOK not set}"
+PERMISSIONS_FILE="$HOME/.claude/permissions.md"
+
+[[ ! -f "$PERMISSIONS_FILE" ]] && exit 0
+
+# Extract undecided entries (lines starting with - after ## Undecided heading)
+UNDECIDED=$(awk '/^## Undecided/{found=1; next} /^## /{found=0} found && /^- /{print}' "$PERMISSIONS_FILE")
+
+[[ -z "$UNDECIDED" ]] && exit 0
+
+COUNT=$(echo "$UNDECIDED" | wc -l | tr -d ' ')
+BODY=$(echo "$UNDECIDED" | head -10)
+[[ $COUNT -gt 10 ]] && BODY=$(printf '%s\n...and %d more' "$BODY" "$((COUNT - 10))")
+
+BODY=$(printf '%s\n\nRun `/permissions` in any Claude session to triage.' "$BODY")
+
+jq -n \
+  --arg subject ":mag: $COUNT undecided tool permission(s) to review" \
+  --arg body "$BODY" \
+  '{text: "\($subject)\n\($body)"}' | \
+  curl -s -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK" > /dev/null

--- a/files/version-alert/check_versions.sh
+++ b/files/version-alert/check_versions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+SLACK_WEBHOOK="${AUDIT_SLACK_WEBHOOK:?AUDIT_SLACK_WEBHOOK not set}"
+STATE_FILE="$HOME/.local/share/version_alert_state.json"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+[[ -f "$STATE_FILE" ]] || echo '{}' > "$STATE_FILE"
+
+PACKAGES=("next" "react")
+ALERTS=""
+
+for pkg in "${PACKAGES[@]}"; do
+    LATEST=$(curl -sf --connect-timeout 5 --max-time 10 "https://registry.npmjs.org/$pkg/latest" | jq -r '.version // empty')
+    [[ -z "$LATEST" ]] && continue
+
+    PREVIOUS=$(jq -r --arg pkg "$pkg" '.[$pkg] // ""' "$STATE_FILE")
+
+    if [[ -n "$PREVIOUS" && "$LATEST" != "$PREVIOUS" ]]; then
+        PREV_MINOR="${PREVIOUS%.*}"
+        NEW_MINOR="${LATEST%.*}"
+        [[ "$PREV_MINOR" != "$NEW_MINOR" ]] && ALERTS+=$'\n:package: '"*$pkg* $PREVIOUS → $LATEST (minor+)"
+    fi
+
+    jq --arg pkg "$pkg" --arg ver "$LATEST" '.[$pkg] = $ver' "$STATE_FILE" > "${STATE_FILE}.tmp" \
+        && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+done
+
+[[ -z "$ALERTS" ]] && exit 0
+
+jq -n \
+    --arg subject ":rocket: Package version updates" \
+    --arg body "$ALERTS" \
+    '{text: "\($subject)\n\($body)"}' | \
+    curl -sf --connect-timeout 5 --max-time 10 -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK" > /dev/null

--- a/files/videos/MEMORY.md
+++ b/files/videos/MEMORY.md
@@ -1,0 +1,9 @@
+# Video Memory
+
+## Interests
+
+(Updated as videos are scored and reviewed)
+
+## Takeaways
+
+(Key learnings from listened content)

--- a/files/videos/scores.md
+++ b/files/videos/scores.md
@@ -1,0 +1,4 @@
+# Video Scores
+
+| Score | Title | Reason | Listened |
+|-------|-------|--------|----------|

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -5,11 +5,44 @@ unalias claude clauden claudev claudevn claudep claudevp claudex claudepod discu
 
 CLAUDE_LOCKFILE=".claude-session.lock"
 
+_iterm_focus_tty() {
+  local tty="$1"
+  [[ -z "$tty" ]] && return 1
+  local result
+  result=$(osascript <<EOF
+tell application "iTerm2"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s ends with "$tty" then
+          select t
+          tell w to select
+          activate
+          return "FOUND"
+        end if
+      end repeat
+    end repeat
+  end repeat
+end tell
+return "NOT_FOUND"
+EOF
+)
+  [[ "$result" == "FOUND" ]]
+}
+
 _claude_tmux() {
   local session="${${PWD##*/}//[.:]/_}"
   if tmux has-session -t "$session" 2>/dev/null; then
     local panes=$(( $(tmux list-panes -t "$session" 2>/dev/null | wc -l) ))
-    [[ "$panes" -gt 1 ]] && { tmux attach -t "$session"; return; }
+    if [[ "$panes" -gt 1 ]]; then
+      local client_tty=$(tmux list-clients -t "$session" -F '#{client_tty}' 2>/dev/null | head -1)
+      if [[ -n "$client_tty" ]]; then
+        _iterm_focus_tty "${client_tty##*/}"
+        return
+      fi
+      tmux attach -t "$session"
+      return
+    fi
   else
     tmux new-session -d -s "$session" -c "$PWD"
   fi
@@ -114,6 +147,10 @@ vps() {
     return
   fi
   if tmux has-session -t "$session" 2>/dev/null; then
+    local client_tty=$(tmux list-clients -t "$session" -F '#{client_tty}' 2>/dev/null | head -1)
+    if [[ -n "$client_tty" ]] && _iterm_focus_tty "${client_tty##*/}"; then
+      return
+    fi
     tmux attach -t "$session"
     return
   fi
@@ -169,22 +206,7 @@ claudes() {
         return
       fi
     fi
-    osascript <<EOF
-tell application "iTerm2"
-  repeat with w in windows
-    repeat with t in tabs of w
-      repeat with s in sessions of t
-        if tty of s ends with "$tty" then
-          select t
-          tell w to select
-          activate
-          return
-        end if
-      end repeat
-    end repeat
-  end repeat
-end tell
-EOF
+    _iterm_focus_tty "$tty" || echo "Could not find iTerm tab for tty $tty"
     return
   fi
 

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -48,11 +48,15 @@ trim () {
 }
 
 aud () {
-  yt-dlp --cookies-from-browser safari -xiwc -o "%(title)s.%(ext)s" "$1"
+  mkdir -p "$HOME/videos/transcripts"
+  yt-dlp --cookies-from-browser safari -xiwc --write-auto-sub --sub-lang en -o "$HOME/videos/%(title)s.%(ext)s" "$1"
+  find "$HOME/videos" -maxdepth 1 -name "*.vtt" -exec mv {} "$HOME/videos/transcripts/" \;
 }
 
 vid () {
-  yt-dlp --cookies-from-browser safari -o "%(title)s.%(ext)s" "$1"
+  mkdir -p "$HOME/videos/transcripts"
+  yt-dlp --cookies-from-browser safari --write-auto-sub --sub-lang en -o "$HOME/videos/%(title)s.%(ext)s" "$1"
+  find "$HOME/videos" -maxdepth 1 -name "*.vtt" -exec mv {} "$HOME/videos/transcripts/" \;
 }
 
 help() {

--- a/files/zsh/volz.zsh
+++ b/files/zsh/volz.zsh
@@ -1,13 +1,13 @@
 typeset -A scaffolds
 scaffolds=(
-  [rails]=_rails
-  [html]=_html
-  [astro]=_astreact
-  [solid]=_solid
-  [angular]=_angular
-  [vite]=_vite
-  [tldr]=_list_scaffolds
-	)
+  rails _rails
+  html _html
+  astro _astreact
+  solid _solid
+  angular _angular
+  vite _vite
+  tldr _list_scaffolds
+)
 
 volz () { # scaffold application # ➜ volz rails busmap
   local option="${1:-tldr}"

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -41,6 +41,12 @@
     dest: "{{ ['~' + macbook_user.stdout, '.claude', 'statusline.sh'] | path_join }}"
     mode: '0755'
 
+- name: Seed permissions.md if not exists
+  copy:
+    src: claude/permissions.md
+    dest: "{{ ['~' + macbook_user.stdout, '.claude', 'permissions.md'] | path_join }}"
+    force: no
+
 - name: Copy Claude skills
   copy:
     src: claude/skills/

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -84,6 +84,39 @@
     src: zsh/dns.zsh
     dest: "{{ ['~' + macbook_user.stdout, '.zsh', 'dns.zsh'] | path_join }}"
 
+- name: Create videos directory
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, 'videos'] | path_join }}"
+    state: directory
+
+- name: Create videos transcripts directory
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, 'videos', 'transcripts'] | path_join }}"
+    state: directory
+
+- name: Create videos memory directory
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, 'videos', 'memory'] | path_join }}"
+    state: directory
+
+- name: Seed videos CLAUDE.md if not exists
+  ansible.builtin.copy:
+    src: videos/MEMORY.md
+    dest: "{{ ['~' + macbook_user.stdout, 'videos', 'CLAUDE.md'] | path_join }}"
+    force: no
+
+- name: Seed videos scores.md if not exists
+  ansible.builtin.copy:
+    src: videos/scores.md
+    dest: "{{ ['~' + macbook_user.stdout, 'videos', 'scores.md'] | path_join }}"
+    force: no
+
+- name: Seed videos memory if not exists
+  ansible.builtin.copy:
+    src: videos/MEMORY.md
+    dest: "{{ ['~' + macbook_user.stdout, 'videos', 'memory', 'MEMORY.md'] | path_join }}"
+    force: no
+
 - name: Makes zsh the cron shell
   ansible.builtin.cron:
     name: SHELL

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -102,6 +102,8 @@
     - "karabiner-elements"
     - "opensuperwhisper"
     - "steipete/tap/repobar"
+    - "tableplus"
+    - "postico"
 
 - name: Copy zshenv
   copy:

--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -48,3 +48,42 @@
     src: pnpm-audit/daily-pnpm-audit.sh
     dest: "{{ [ansible_env.HOME, 'work', 'crons', 'pnpm-audit', 'daily-pnpm-audit.sh'] | path_join }}"
     mode: "0755"
+
+- name: Create permissions-alert directory
+  file:
+    path: "{{ [ansible_env.HOME, 'work', 'crons', 'permissions-alert'] | path_join }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy permissions-alert script
+  copy:
+    src: permissions-alert/check_permissions.sh
+    dest: "{{ [ansible_env.HOME, 'work', 'crons', 'permissions-alert', 'check_permissions.sh'] | path_join }}"
+    mode: "0755"
+
+- name: Setup permissions-alert cron (Tue/Fri at 09:00)
+  ansible.builtin.cron:
+    name: permissions alert
+    minute: "0"
+    hour: "9"
+    weekday: "2,5"
+    job: ". $HOME/.zshrc && {{ ansible_env.HOME }}/work/crons/permissions-alert/check_permissions.sh"
+
+- name: Create version-alert directory
+  file:
+    path: "{{ [ansible_env.HOME, 'work', 'crons', 'version-alert'] | path_join }}"
+    state: directory
+    mode: "0755"
+
+- name: Copy version-alert script
+  copy:
+    src: version-alert/check_versions.sh
+    dest: "{{ [ansible_env.HOME, 'work', 'crons', 'version-alert', 'check_versions.sh'] | path_join }}"
+    mode: "0755"
+
+- name: Setup version-alert cron (daily at 10:00)
+  ansible.builtin.cron:
+    name: version alert
+    minute: "0"
+    hour: "10"
+    job: ". $HOME/.zshrc && {{ ansible_env.HOME }}/work/crons/version-alert/check_versions.sh"


### PR DESCRIPTION
add permissions management, monitoring alerts, and session improvements

- Add permissions skill and permissions.md for tracking undecided tool calls
- Add permissions-alert cron to Slack when undecided permissions accumulate
- Add version-alert cron to Slack on npm minor+ version bumps
- Add post-commit waypoints to commit command (permissions, memory, drift, TODO)
- Extract _iterm_focus_tty helper, reuse in _claude_tmux, vps, and claudes
- Focus existing tmux session tab instead of attaching duplicate
- Expand disk guardian with ballast file, critical mode, and more cache targets
- Color-code disk free in statusline by available space
- Add ZSH, shell, and JSON syntax validation to CI workflow
- Set up ~/videos directory with transcript scoring and AI-scored catalogue
- Update aud/vid to download to ~/videos with auto-subtitles
- Fix volz.zsh associative array syntax
- Add speak skill guidance for "Response required" on permission prompts
- Add tableplus and postico to brew casks
- Seed permissions.md via Ansible with force: no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI pre-flight checks for ZSH, shell, and JSON syntax
  * Automated permission and package-version alerting scripts with scheduled checks
  * Post-commit housekeeping steps: permission triage, memory capture, drift detection, TODO harvesting

* **Improvements**
  * Disk-space guardian: ballast-based recovery, broader cleanup, and colored free-space display
  * Video/audio downloads auto-save English subtitles and organize transcripts
  * Terminal/tab focusing enhancements and added macOS apps

* **Documentation**
  * Permissions governance and permissions-review skill docs; video tracking/memory templates

* **Chores**
  * Seeded files and cron jobs for alerts and video workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->