### PR TITLE
container/bind port localhost

### DIFF
--- a/files/bin/whisper_wrapper
+++ b/files/bin/whisper_wrapper
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Whisper wrapper: audio cues around OpenSuperWhisper recording toggle
+# Designed for screenless (hiking) use with a Bluetooth macro pad
+#
+
+STATE_FILE="/tmp/whisper_recording_state"
+MONITOR_PID_FILE="/tmp/whisper_monitor.pid"
+CUE_DIR="$HOME/.local/share/whisper_cues"
+SW_DB="$HOME/Library/Application Support/ru.starmel.OpenSuperWhisper/recordings.sqlite"
+
+play_cue() {
+  afplay "$CUE_DIR/$1.aiff" &
+}
+
+play_cue_sync() {
+  afplay "$CUE_DIR/$1.aiff" &
+  local pid=$!
+  ( sleep 3 && kill "$pid" 2>/dev/null ) &
+  wait "$pid" 2>/dev/null
+}
+
+trigger_superwhisper() {
+  osascript -e 'tell application "System Events" to key code 47 using command down' &
+}
+
+kill_monitor() {
+  [[ -f "$MONITOR_PID_FILE" ]] && {
+    kill "$(cat "$MONITOR_PID_FILE")" 2>/dev/null
+    rm -f "$MONITOR_PID_FILE"
+  }
+}
+
+get_row_count() {
+  sqlite3 "$SW_DB" "SELECT count(*) FROM recordings" 2>/dev/null || echo "0"
+}
+
+monitor_transcription() {
+  local count_before="$1"
+  local max_wait=200
+  local elapsed=0
+
+  while (( elapsed < max_wait )); do
+    sleep 0.3
+    elapsed=$(( elapsed + 1 ))
+    local count_now
+    count_now=$(get_row_count)
+    [[ "$count_now" -gt "$count_before" ]] && {
+      play_cue "done"
+      break
+    }
+  done
+
+  rm -f "$MONITOR_PID_FILE"
+}
+
+start_recording() {
+  kill_monitor
+  echo "recording" > "$STATE_FILE"
+  play_cue_sync "listening"
+  trigger_superwhisper
+}
+
+stop_recording() {
+  local count_before
+  count_before=$(get_row_count)
+
+  rm -f "$STATE_FILE"
+  play_cue "transcribing"
+  trigger_superwhisper
+
+  kill_monitor
+  monitor_transcription "$count_before" &
+  echo $! > "$MONITOR_PID_FILE"
+}
+
+if [[ -f "$STATE_FILE" ]]; then
+  stop_recording
+else
+  start_recording
+fi

--- a/files/git/pre-push
+++ b/files/git/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+branch="$(git branch --show-current)"
+
+if [ "$branch" = "main" ]; then
+  echo "Push to main branch is blocked."
+  exit 1
+fi

--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -63,7 +63,24 @@
             ]
           },
           {
-            "description": "⌘; to /speak + SuperWhisper",
+            "description": "⌘. to whisper wrapper (intercept SuperWhisper hotkey)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "period",
+                  "modifiers": { "mandatory": ["command"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/whisper_wrapper"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "⌘; to /speak + start recording",
             "manipulators": [
               {
                 "type": "basic",
@@ -79,7 +96,72 @@
                   { "key_code": "a" },
                   { "key_code": "k" },
                   { "key_code": "spacebar" },
-                  { "key_code": "period", "modifiers": ["command"] }
+                  { "shell_command": "/usr/local/bin/whisper_wrapper" }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "F18: Toggle whisper recording (macro pad key 1)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "f18",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/whisper_wrapper"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "F17: Enter/submit (macro pad key 2)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "f17",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  { "key_code": "return_or_enter" }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "F16: Ctrl+C interrupt (macro pad key 3)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "f16",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "key_code": "c",
+                    "modifiers": ["control"]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "F15: Escape (macro pad key 4)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "f15",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  { "key_code": "escape" }
                 ]
               }
             ]

--- a/roles/agent/templates/compose.override.yml.j2
+++ b/roles/agent/templates/compose.override.yml.j2
@@ -2,3 +2,9 @@ services:
   claude-agent:
     volumes:
       - {{ [agent_deploy_dir, '.ssh'] | path_join }}:/home/agent/.ssh
+    ports:
+      - "127.0.0.1:3000:3000"
+    mem_limit: 2g
+    cpus: 2
+    security_opt:
+      - no-new-privileges:true

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -13,6 +13,30 @@
     mode: '0755'
   become: true
 
+- name: Copy whisper wrapper script
+  ansible.builtin.copy:
+    src: bin/whisper_wrapper
+    dest: /usr/local/bin/whisper_wrapper
+    mode: '0755'
+  become: true
+
+- name: Create whisper cues directory
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, '.local', 'share', 'whisper_cues'] | path_join }}"
+    state: directory
+  when: inventory_hostname != 'github-runner.localhost'
+
+- name: Generate whisper audio cues
+  ansible.builtin.shell: >
+    say -o "$HOME/.local/share/whisper_cues/{{ item }}.aiff" "{{ item }}"
+  args:
+    creates: "{{ ['~' + macbook_user.stdout, '.local', 'share', 'whisper_cues', item + '.aiff'] | path_join }}"
+  loop:
+    - listening
+    - transcribing
+    - done
+  when: inventory_hostname != 'github-runner.localhost'
+
 - name: Copy tmux config
   ansible.builtin.copy:
     src: tmux.conf

--- a/roles/functions/tasks/git.yml
+++ b/roles/functions/tasks/git.yml
@@ -42,6 +42,12 @@
     dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'commit-msg'] | path_join }}"
     mode: a+x
 
+- name: Copy global pre-push hook
+  copy:
+    src: git/pre-push
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'pre-push'] | path_join }}"
+    mode: a+x
+
 - name: Create blank template commit file
   copy:
     src: git/commit-msg-template

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -105,6 +105,7 @@
     - "tableplus"
     - "postico"
     - "hamed-elfayome/claude-usage/claude-usage-tracker"
+    - "stats"
 
 - name: Copy zshenv
   copy:


### PR DESCRIPTION
add whisper wrapper with audio cues and macro pad bindings

- Add whisper_wrapper script for screenless SuperWhisper control with audio feedback
- Add Karabiner macro pad bindings: F18 whisper, F17 enter, F16 ctrl+c, F15 escape
- Remap ⌘. to whisper wrapper, update ⌘; to use wrapper instead of raw hotkey
- Add Ansible tasks to install wrapper and generate audio cues
- Bind container port 3000 to localhost with memory/CPU limits and no-new-privileges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts and F-key mappings to toggle voice recording with audible cues (listening, transcribing, done).
  * Background monitoring detects completed transcriptions and signals arrival.

* **Chores**
  * macOS installer now deploys the helper script and audio cues; added a small utility to the install list.
  * Local agent gets runtime and security limits.
  * New Git pre-push hook prevents pushes to the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->