### PR TITLE
feat: shell navigation enhancements and Ansible portability

### DIFF
--- a/files/bin/speak
+++ b/files/bin/speak
@@ -20,15 +20,24 @@ _speak() {
   trap - INT TERM
 }
 
-[[ $# -eq 0 ]] && _speak "Nothing to speak." && exit 1
+_dispatch() {
+  if [[ -n "$SSH_CONNECTION" ]]; then
+    local client_ip="${SSH_CONNECTION%% *}"
+    ssh -o ConnectTimeout=3 "$client_ip" -- "/usr/local/bin/speak $(printf '%q' "$1")" && return
+    _speak "$1"
+  else
+    _speak "$1"
+  fi
+}
 
-# If argument is a file, read its contents
+[[ $# -eq 0 ]] && _dispatch "Nothing to speak." && exit 1
+
 if [[ -f "$1" ]]; then
   if [[ "$1" == *.json ]] && jq -e '.input' "$1" &>/dev/null; then
-    _speak "$(jq -r '.input' "$1")"
+    _dispatch "$(jq -r '.input' "$1")"
   else
-    _speak "$(cat "$1")"
+    _dispatch "$(cat "$1")"
   fi
 else
-  _speak "$*"
+  _dispatch "$*"
 fi

--- a/files/git/pre-push
+++ b/files/git/pre-push
@@ -2,6 +2,11 @@
 branch="$(git branch --show-current)"
 
 if [ "$branch" = "main" ]; then
+  allowlist="$HOME/.config/git/push-main-allowlist"
+  if [ -f "$allowlist" ]; then
+    remote_url="$(git remote get-url origin 2>/dev/null)"
+    grep -qFx "$remote_url" "$allowlist" && exit 0
+  fi
   echo "Push to main branch is blocked."
   exit 1
 fi

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -263,22 +263,31 @@ with open(sys.argv[1]) as fh:
     done
   }
 
-  if [[ -z "$1" ]]; then
-    _conv_sorted
-    _conv_display
-  elif [[ "$1" =~ ^[0-9]+$ ]]; then
-    _conv_sorted
+  _conv_search() {
+    local matches=$(grep -rFl "$1" "$claude_dir"/*/*.jsonl 2>/dev/null)
+    [[ -z "$matches" ]] && { echo "No conversations matching '$1'"; return 1; }
+    conv_files=($(echo "$matches" | xargs ls -t 2>/dev/null | head -25))
+  }
+
+  _conv_resume() {
     local target=$1
     [[ $target -lt 1 || $target -gt ${#conv_files[@]} ]] && { echo "No conversation at index $target (${#conv_files[@]} available)"; return 1; }
     local file="${conv_files[$target]}"
     local session_id="${file:t:r}"
     echo "Resuming: $session_id"
     _claude_run --resume "$session_id"
-  else
-    local matches=$(grep -rFl "$1" "$claude_dir"/*/*.jsonl 2>/dev/null)
-    [[ -z "$matches" ]] && { echo "No conversations matching '$1'"; return 0; }
-    conv_files=($(echo "$matches" | xargs ls -t 2>/dev/null | head -25))
+  }
+
+  if [[ -z "$1" ]]; then
+    _conv_sorted
     _conv_display
+  elif [[ "$1" =~ ^[0-9]+$ ]]; then
+    _conv_sorted
+    _conv_resume "$1"
+  elif [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+    _conv_search "$1" && _conv_resume "$2"
+  else
+    _conv_search "$1" && _conv_display
   fi
 }
 

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -494,14 +494,6 @@ gtop () {
   cd $(git rev-parse --show-toplevel)
 }
 
-mv () { # git mv in repos, regular mv otherwise # ➜ mv old.txt new.txt
-  if [[ "$1" != -* ]] && git rev-parse --is-inside-work-tree &>/dev/null \
-    && { git ls-files --error-unmatch "$1" &>/dev/null || { [[ -d "$1" ]] && git ls-files -- "$1/" | read -r; }; }; then
-    git mv "$@" 2>/dev/null || command mv "$@"
-  else
-    command mv "$@"
-  fi
-}
 
 ginit () {
   git init

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -167,6 +167,7 @@ install() {
 
 cleanup(){
   find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
+  find . -name ".next" -type d -prune -exec rm -rf '{}' +
 }
 
 discogs() {

--- a/files/zsh/nav.zsh
+++ b/files/zsh/nav.zsh
@@ -60,6 +60,49 @@ _completemarks() {
 compctl -K _completemarks jump
 compctl -K _completemarks unmark
 
+# Move wrapper: update marks when directories move
+
+mv() {
+  local _args=()
+  for arg in "$@"; do
+    [[ "$arg" != -* ]] && _args+=("$arg")
+  done
+
+  # Resolve source paths before the move (while they still exist)
+  local -a _srcs_abs=()
+  if (( ${#_args} >= 2 )) && [[ -d "$MARKPATH" ]]; then
+    for src in "${_args[@]:0:$((${#_args} - 1))}"; do
+      [[ "$src" != /* ]] && src="$PWD/$src"
+      _srcs_abs+=("${src:A}")
+    done
+  fi
+
+  # Use git mv for tracked files, plain mv otherwise
+  if [[ "${_args[1]}" != -* ]] && git rev-parse --is-inside-work-tree &>/dev/null \
+    && { git ls-files --error-unmatch "${_args[1]}" &>/dev/null || { [[ -d "${_args[1]}" ]] && git ls-files -- "${_args[1]}/" | read -r; }; }; then
+    git mv "$@" 2>/dev/null || command mv "$@" || return $?
+  else
+    command mv "$@" || return $?
+  fi
+
+  (( ${#_srcs_abs} == 0 )) && return
+  local _dst="${_args[-1]}"
+  [[ "$_dst" != /* ]] && _dst="$PWD/$_dst"
+
+  for mark in "$MARKPATH"/*(N); do
+    [[ ! -L "$mark" ]] && continue
+    local target=$(readlink "$mark")
+    for _src in "${_srcs_abs[@]}"; do
+      [[ "$target" != "$_src" && "$target" != "$_src"/* ]] && continue
+      local new_target
+      [[ -d "$_dst" ]] && new_target="${_dst}/${_src:t}${target#$_src}" || new_target="${_dst}${target#$_src}"
+      ln -sf "$new_target" "$mark"
+      echo "mark '${mark:t}' → ${new_target/#$HOME/\~}"
+      break
+    done
+  done
+}
+
 # Terminal profile per directory
 
 cpr() { # Set terminal profile for directory # ➜ cpr coffee
@@ -87,12 +130,12 @@ chpwd() {
 # Directory history
 
 _track_directory() {
-  [[ ! -d ".git" ]] && return
   local current="$PWD"
+  [[ "$current" == "$HOME" ]] && return
   local temp=$(mktemp) || return
   echo "$current" > "$temp"
   [[ -f "$DIR_HISTORY_FILE" ]] && grep -v "^${current}$" "$DIR_HISTORY_FILE" >> "$temp"
-  head -100 "$temp" > "${DIR_HISTORY_FILE}.new" && mv "${DIR_HISTORY_FILE}.new" "$DIR_HISTORY_FILE"
+  head -100 "$temp" > "${DIR_HISTORY_FILE}.new" && command mv "${DIR_HISTORY_FILE}.new" "$DIR_HISTORY_FILE"
   rm -f "$temp"
 }
 
@@ -102,13 +145,17 @@ _format_repo_line() {
 
   display="${repo/#$HOME/~}"
 
-  # Non-git directories: just show path
+  # Prefix: ◆ for Makefile projects, space otherwise
+  local prefix=" "
+  [[ -f "$repo/Makefile" ]] && prefix=$'\e[36m'"◆"$'\e[0m'
+
+  # Non-git directories
   if [[ ! -d "$repo/.git" ]]; then
-    local visible_len=${#display}
+    local visible_len=$((${#display} + 2))  # prefix + space
     local padding=$((pad_width - visible_len))
     (( padding < 1 )) && padding=1
     local pad=$(printf '%*s' "$padding" '')
-    printf "%s%s%7s %7s\n" "$display" "$pad" "" ""
+    printf "%s %s%s%7s %7s\n" "$prefix" "$display" "$pad" "" ""
     return
   fi
 
@@ -153,7 +200,7 @@ _format_repo_line() {
   [[ "$files" == "0" ]] && files_display=""
 
   # Style: blue parens, red branch
-  local visible_len=$((${#display} + ${#branch_display} + 5))  # " () X"
+  local visible_len=$((${#display} + ${#branch_display} + 7))  # "P path (branch) X"
   local padding=$((pad_width - visible_len))
   (( padding < 1 )) && padding=1
   local pad=$(printf '%*s' "$padding" '')
@@ -162,8 +209,8 @@ _format_repo_line() {
   local commits_display="$commits"
   [[ "$commits" == "0" ]] && commits_display=""
 
-  printf "%s "$'\e[34m'"("$'\e[31m'"%s"$'\e[34m'")"$'\e[0m'" %s%s%7s %7s\n" \
-    "$display" "$branch_display" "$icon" "$pad" "$commits_display" "$files_display"
+  printf "%s %s "$'\e[34m'"("$'\e[31m'"%s"$'\e[34m'")"$'\e[0m'" %s%s%7s %7s\n" \
+    "$prefix" "$display" "$branch_display" "$icon" "$pad" "$commits_display" "$files_display"
 }
 
 dh() { # Directory history # ➜ dh
@@ -182,7 +229,7 @@ dh() { # Directory history # ➜ dh
     count="$2"
   fi
 
-  printf "%60s %7s %7s\n" "" "commits" "changed"
+  printf "%62s %7s %7s\n" "" "commits" "changed"
   local i=0
   head -n "$count" "$DIR_HISTORY_FILE" | while read -r repo; do
     ((i++))

--- a/roles/functions/tasks/dnsmasq.yml
+++ b/roles/functions/tasks/dnsmasq.yml
@@ -1,12 +1,12 @@
 - name: Add yay domain to dnsmasq.conf
   lineinfile:
-    path: "/opt/homebrew/etc/dnsmasq.conf"
+    path: "{{ brew_prefix }}/etc/dnsmasq.conf"
     line:  "address=/.{{ item.domain }}/{{ item.ip }}"
     insertbefore: EOF
   with_items: "{{ local_domains }}"
 
 - name: Find dnsmasq plist file
-  ansible.builtin.command: find /opt/homebrew/Cellar -name homebrew.mxcl.dnsmasq.plist
+  ansible.builtin.command: find {{ brew_prefix }}/Cellar -name homebrew.mxcl.dnsmasq.plist
   register: dnsmasq_plist
 
 - name: Print dnsmasq plist file path

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -3,65 +3,76 @@
   become: true
   become_user: "{{ brew_user.stdout }}"
   homebrew:
-    name:
-      [
-        "yt-dlp",
-        "gh",
-        "jq",
-        "wget",
-        "dnsmasq",
-        "gcc",
-        "openssl",
-        "cmake",
-        "git",
-        "moreutils",
-        "findutils",
-        "gnupg",
-        "grep",
-        "screen",
-        "pigz",
-        "tree",
-        "ffmpeg",
-        "shared-mime-info",
-        "nginx",
-        "graphviz",
-        "node@{{ node_version }}",
-        "pnpm",
-        "bun",
-        "zsh",
-        "zsh-completions",
-        "zsh-autosuggestions",
-        "zsh-syntax-highlighting",
-        "direnv",
-        "watch",
-        "nmap",
-        "htop",
-        "tmux",
-        "neovim",
-        "postgresql",
-        "redis",
-        "lima",
-        "glow",
-        "n",
-        "repomix",
-        "podman",
-        "autossh",
-        "act",
-        "dopplerhq/cli/doppler",
-        "stripe/stripe-cli/stripe",
-        "wireguard-tools",
-        "python",
-        "ripgrep",
-        "neonctl",
-        "uv",
-        "semgrep",
-        "shellcheck",
-        "librsvg",
-        "marcus/tap/nightshift",
-        "marcus/tap/td",
-        "marcus/tap/sidecar",
-        ]
+    name: "{{ brew_core_packages + ['ffmpeg'] }}"
     state: present
+  when: ansible_distribution_version is version('13.0', '>=')
+  vars:
+    brew_core_packages: &core_packages
+      - "yt-dlp"
+      - "gh"
+      - "jq"
+      - "wget"
+      - "dnsmasq"
+      - "gcc"
+      - "openssl"
+      - "cmake"
+      - "git"
+      - "moreutils"
+      - "findutils"
+      - "gnupg"
+      - "grep"
+      - "screen"
+      - "pigz"
+      - "tree"
+      - "shared-mime-info"
+      - "nginx"
+      - "graphviz"
+      - "node@{{ node_version }}"
+      - "pnpm"
+      - "bun"
+      - "zsh"
+      - "zsh-completions"
+      - "zsh-autosuggestions"
+      - "zsh-syntax-highlighting"
+      - "direnv"
+      - "watch"
+      - "nmap"
+      - "htop"
+      - "tmux"
+      - "neovim"
+      - "postgresql"
+      - "redis"
+      - "lima"
+      - "glow"
+      - "n"
+      - "repomix"
+      - "podman"
+      - "autossh"
+      - "act"
+      - "dopplerhq/cli/doppler"
+      - "stripe/stripe-cli/stripe"
+      - "wireguard-tools"
+      - "python"
+      - "ripgrep"
+      - "neonctl"
+      - "uv"
+      - "semgrep"
+      - "shellcheck"
+      - "librsvg"
+      - "marcus/tap/nightshift"
+      - "marcus/tap/td"
+      - "marcus/tap/sidecar"
+
+- name: install core packages (best effort, older macOS)
+  become: true
+  become_user: "{{ brew_user.stdout }}"
+  homebrew:
+    name: "{{ brew_core_packages }}"
+    state: present
+  when: ansible_distribution_version is version('13.0', '<')
+  ignore_errors: true
+  vars:
+    brew_core_packages: *core_packages
 
 - name: install packages requiring macOS 11+
   become: true
@@ -149,4 +160,4 @@
   when: not claude_installed.stat.exists
 
 - name: link node
-  shell: /opt/homebrew/bin/brew link --overwrite node@{{ node_version }}
+  shell: "{{ brew_location.stdout }} link --overwrite node@{{ node_version }}"

--- a/roles/whoami/tasks/main.yml
+++ b/roles/whoami/tasks/main.yml
@@ -39,6 +39,11 @@
 - debug: var=brew_user.stdout
   when: ansible_os_family == "Darwin"
 
+- name: derive brew prefix
+  set_fact:
+    brew_prefix: "{{ brew_location.stdout | dirname | dirname }}"
+  when: ansible_os_family == "Darwin"
+
 - name: print role name
   set_fact:
     parent_role_name: "{{ role_name }}"


### PR DESCRIPTION
- Add mv wrapper that auto-updates bookmark symlinks when directories move
- Show ◆ prefix for Makefile projects in directory history
- Track all directories in history, not just git repos
- Add SSH dispatch to speak script for remote sessions
- Add push-to-main allowlist in pre-push hook
- Refactor conversation search with search+resume two-arg mode
- Replace hardcoded /opt/homebrew with dynamic brew_prefix variable
- Split brew install for macOS 13+ vs older with best-effort fallback
- Clean up .next directories in cleanup function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote execution for speak commands with transparent local fallback
  * Main-branch push can be allowed via an allowlist check
  * Conversation search and resume actions for Claude workflows
  * Directory move now updates saved marks after relocation

* **Improvements**
  * Wider, clearer directory history display formatting
  * macOS install logic adapts to OS version
  * Cleanup now removes Next.js build artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->