### PR TITLE
wezterm mods

### DIFF
--- a/files/wezterm.lua
+++ b/files/wezterm.lua
@@ -140,6 +140,8 @@ config.colors = {
   },
 }
 
+config.hyperlink_rules = wezterm.default_hyperlink_rules()
+
 config.mouse_bindings = {
   {
     event = { Up = { streak = 1, button = 'Left' } },
@@ -156,6 +158,29 @@ config.keys = {
   { key = 'k', mods = 'LEADER', action = wezterm.action.ActivatePaneDirection 'Up' },
   { key = 'l', mods = 'LEADER', action = wezterm.action.ActivatePaneDirection 'Right' },
   { key = 'x', mods = 'LEADER', action = wezterm.action.CloseCurrentPane { confirm = false } },
+  { key = 'n', mods = 'SUPER', action = wezterm.action.SpawnCommandInNewWindow { cwd = wezterm.home_dir } },
+  { key = ' ', mods = 'SUPER', action = wezterm.action_callback(function(window, pane)
+    local home = wezterm.home_dir
+    local history_file = home .. '/.dir_history'
+    local f = io.open(history_file, 'r')
+    if not f then return end
+    local choices = {}
+    for line in f:lines() do
+      local label = line:gsub('^' .. home, '~')
+      table.insert(choices, { id = line, label = label })
+    end
+    f:close()
+    window:perform_action(wezterm.action.InputSelector {
+      title = 'Jump to directory',
+      fuzzy = true,
+      choices = choices,
+      action = wezterm.action_callback(function(_, _, id, label)
+        if id then
+          pane:send_text('cd ' .. id .. '\n')
+        end
+      end),
+    }, pane)
+  end) },
 }
 
 wezterm.on('user-var-changed', function(window, _, name, _)

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -200,7 +200,7 @@ commits () { # List recent commits # ➜ commits 5
   local branch="$(git branch --show-current)"
   local default=$(_default_branch)
   if [[ $branch = $default ]]; then
-    [[ $1 ]] && no=$1 || no=$(git rev-list --count $default)
+    [[ $1 ]] && no=$1 || no=20
     git log --pretty=format:"%ar %s" |head -$no | _colorize_commit_type
   else
     unique_to_branch=$(git rev-list --count $default..$branch)

--- a/files/zsh/nav.zsh
+++ b/files/zsh/nav.zsh
@@ -25,6 +25,10 @@ mcd() {
   cd "$1"
 }
 
+tcd() {
+  cd "$HOME/${1:-.}"
+}
+
 # Marks system
 
 jump() {


### PR DESCRIPTION
WezTerm enhancements and shell navigation improvements

- Add CMD+Space fuzzy directory jumper from dir history
- Add CMD+N to open new windows in home directory
- Add tcd function for cd relative to home directory
- Cap commits output to 20 on main branch
- Enable explicit hyperlink rules in WezTerm config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Super+N shortcut to open new terminal windows.
  * Added Super+Space shortcut to browse and navigate to previously visited directories.
  * Introduced hyperlink rules configuration.
  * Added new shell function for quick directory navigation.

* **Changes**
  * Modified commit history display limit to 20 commits on the default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->