### PR TITLE
Fix typo in scripts function error message

### DIFF
--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -384,7 +384,7 @@ window() {
 }
 
 scripts () {
-  [[ -f package.json ]] && jq .scripts package.json || echo "package.json not round. To create run ➜ npm init"
+  [[ -f package.json ]] && jq .scripts package.json || echo "package.json not found. To create run ➜ npm init"
 }
 
 _delete_temp_page () {


### PR DESCRIPTION
## Summary
Fixed a typo in the error message displayed by the `scripts()` function when `package.json` is not found.

## Changes
- Corrected "not round" to "not found" in the error message shown when `package.json` is missing

## Details
The `scripts()` function in `files/zsh/main.zsh` displays a helpful error message when users try to view npm scripts but don't have a `package.json` file. The message contained a typo that has now been corrected to improve clarity and professionalism.

https://claude.ai/code/session_01PS41rDhiqxbUWMNdJYGYgE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in an error message to improve clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->