### PR TITLE
obsidian

### DIFF
--- a/files/claude/config.md
+++ b/files/claude/config.md
@@ -163,6 +163,20 @@ When using Playwright MCP for browser automation and testing:
   - `/review 4` - Reference only (shows what's not covered)
 - Always provide a grade A-F and score out of 100
 
+# Second Brain
+
+When the user says things like "remember this", "save this", "brain this", "we should remember this", or "note this down" — write a fleeting note to `~/second-brain/Inbox/`. Use filename format `YYYYMMDD-HHMMSS-slug.md` with frontmatter:
+
+```yaml
+---
+source: <derived from current working directory or git remote name>
+tags: []
+created: YYYY-MM-DDTHH:MM:SS
+---
+```
+
+Keep notes atomic — one insight per note. Include enough context that future-you understands it without the original conversation.
+
 # Recovery & Steering
 
 - Don't silently downgrade implementations — if the task says config-driven, don't hardcode; if it says error handling, don't skip it "for now"

--- a/files/claude/skills/curate/SKILL.md
+++ b/files/claude/skills/curate/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: curate
+description: Review and promote second brain inbox notes to permanent knowledge. Run from ~/second-brain/.
+user-invocable: true
+---
+
+# Curate Second Brain
+
+Review fleeting notes in `Inbox/` and decide what becomes permanent knowledge.
+
+## Process
+
+1. List all files in `Inbox/`
+2. If empty, say so and suggest the user capture some notes first
+3. For each note, read it and then:
+   - Search `Zettelkasten/` and `MOCs/` for related existing notes
+   - Present the note with a recommendation: **Promote**, **Merge**, **File**, or **Discard**
+   - Wait for user decision before proceeding
+4. When promoting:
+   - Rewrite with a clean title and proper context
+   - Add `[[wikilinks]]` to related Zettelkasten notes
+   - Update or create relevant MOCs
+   - Move from `Inbox/` to `Zettelkasten/`
+   - Change frontmatter `type: fleeting` to `type: permanent`
+5. When merging: append content to the existing note, delete the inbox file
+6. When filing: move to `Resources/`, `Literature/`, or `Projects/` as appropriate
+7. When discarding: delete the file
+
+## After Processing
+
+- Show a summary: X promoted, X merged, X filed, X discarded
+- If any new MOCs were created, mention them
+- If any existing MOCs were updated, mention them

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -209,6 +209,12 @@ claudewright() {
   claude mcp add playwright npx @playwright/mcp@latest
 }
 
+curate() {
+  local vault="$HOME/second-brain"
+  [[ -d "$vault" ]] || { echo "No vault at $vault"; return 1; }
+  cd "$vault" && command claude -p "/curate"
+}
+
 # List Claude sessions, or jump to one by index (active first, orphans last)
 claudes() {
   local idx="${1:-}"

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -26,10 +26,18 @@
     patterns: "*.png"
   register: wallpaper_files
 
-- name: Set first wallpaper as default
-  shell: >
-    osascript -e 'tell application "Finder" to set desktop picture to
-    POSIX file "{{ (wallpaper_files.files | sort(attribute='path') | first).path }}"'
+- name: Set per-space wallpapers alphabetically
+  vars:
+    sorted_wallpapers: "{{ wallpaper_files.files | sort(attribute='path') | map(attribute='path') | list }}"
+    space_key_codes: [18, 19, 20, 21, 23, 22, 26, 28, 25, 29, 12, 13, 14, 15, 17, 16]
+  shell: |
+    osascript {% for wp in sorted_wallpapers %} \
+      -e 'tell application "System Events" to key code {{ space_key_codes[loop.index0] }} using {control down}' \
+      -e 'delay 2' \
+      -e 'tell application "Finder" to set desktop picture to POSIX file "{{ wp }}"' \
+      -e 'delay 0.5' \
+    {% endfor %} \
+      -e 'tell application "System Events" to key code 18 using {control down}'
   changed_when: false
   when: wallpaper_files.files | length > 0
 

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -68,6 +68,22 @@
     src: claude/agents/
     dest: "{{ ['~' + macbook_user.stdout, '.claude', 'agents'] | path_join }}/"
 
+- name: Create second brain vault directories
+  file:
+    path: "{{ ['~' + macbook_user.stdout, 'second-brain', item] | path_join }}"
+    state: directory
+  loop:
+    - Inbox
+    - Projects
+    - Areas
+    - Resources
+    - Archive
+    - Zettelkasten
+    - Literature
+    - MOCs
+    - Daily
+    - Templates
+
 - name: Create gemini directory
   file:
     path: "{{ ['~' + macbook_user.stdout, '.gemini'] | path_join }}"


### PR DESCRIPTION
add remember this to global claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Second Brain" note-taking guidelines with standardized fleeting-note format, YAML frontmatter template, and expanded Recovery & Steering guidance (verification, stoppage/ask rules, no unnecessary TODOs).
* **New Features**
  * Added a manual curation workflow for processing Inbox notes into permanent knowledge.
  * Added a command to invoke the curate workflow from the shell.
  * Automatic per-space wallpaper assignment on desktops.
* **Chores**
  * Create standard Second Brain vault directories automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->