### PR TITLE
resume

### DIFF
--- a/files/wezterm.lua
+++ b/files/wezterm.lua
@@ -3,7 +3,8 @@ local config = wezterm.config_builder()
 
 config.leader = { key = 'a', mods = 'CTRL', timeout_milliseconds = 1000 }
 config.term = 'xterm-256color'
-config.font_size = 14.0
+config.font = wezterm.font('Monaco')
+config.font_size = 16.0
 config.color_schemes = {
   coffee = {
     foreground = '#ffca28',

--- a/files/zsh/gsd.zsh
+++ b/files/zsh/gsd.zsh
@@ -213,6 +213,10 @@ gsds() {
   $found_any || echo "No GSD projects found (no hubs with .planning/STATE.md)"
 }
 
+resume() {
+  [[ -f ".planning/STATE.md" ]] && claude "/gsd:resume-work" || claude
+}
+
 gsd() {
   local cmd="$1"
   [[ -n "$cmd" ]] && shift


### PR DESCRIPTION
add resume function and update wezterm font

- Add resume() shell function to auto-resume GSD work or start fresh Claude session
- Switch wezterm font to Monaco at size 16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new `resume` command for terminal workflows that enables quick work continuation

* **Updates**
  * Enhanced terminal display with Monaco font and increased default size to 16pt for improved visibility and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->