### PR TITLE
ctrln

### DIFF
--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -169,6 +169,23 @@
             ]
           },
           {
+            "description": "Ctrl+N: New WezTerm window in current space",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "n",
+                  "modifiers": { "mandatory": ["control"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/Applications/WezTerm.app/Contents/MacOS/wezterm start &"
+                  }
+                ]
+              }
+            ]
+          },
+          {
             "description": "F15: Escape (macro pad key 4)",
             "manipulators": [
               {


### PR DESCRIPTION
add Ctrl+N global shortcut to spawn WezTerm in current space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Ctrl+N) to launch WezTerm terminal emulator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->