### PR TITLE
aud

### DIFF
--- a/files/claude/commands/commit.md
+++ b/files/claude/commands/commit.md
@@ -74,3 +74,11 @@ Scan the session for loose ends: things we said we'd do later, tests we skipped,
 - Read the project's `TODO.md`
 - Append new items that aren't already listed
 - Format: `- [ ] Description (from session YYYY-MM-DD)`
+
+### 11. Insight capture
+Scan the session for novel insights worth preserving: a pattern that solved a hard problem, a decision with non-obvious reasoning, a gotcha that cost time, or a workflow worth repeating. If any exist:
+- Write each as a fleeting note to `~/second-brain/Inbox/` using standard format (`YYYYMMDD-HHMMSS-slug.md` with frontmatter)
+- Include WHY it matters, not just what happened
+- Tag with `tags: [auto-captured]` to distinguish from manual captures
+- If the insight is a reusable workflow, use `YYYYMMDD-HHMMSS-skill-slug.md` filename and tag `skill-candidate`
+- If nothing genuinely novel happened in this session, skip silently

--- a/files/claude/config.md
+++ b/files/claude/config.md
@@ -22,6 +22,7 @@ Never edit `~/.claude/` directly. Edit macfair, then tell user to run `make clau
 - Care about errors and accessibility (a11y)
 - Use the actual current date from context - don't hallucinate it being a year ago
 - Express uncertainty honestly rather than guessing confidently
+- When a task touches 3+ independent files or layers, use parallel subagents rather than working sequentially
 
 # Git
 
@@ -175,7 +176,26 @@ created: YYYY-MM-DDTHH:MM:SS
 ---
 ```
 
-Keep notes atomic — one insight per note. Include enough context that future-you understands it without the original conversation.
+Keep notes atomic — one insight per note. Include enough context that future-you understands it without the original conversation. Always capture WHY it matters, not just what happened.
+
+When starting a new project or facing a non-trivial design decision, search `~/second-brain/notes/` for relevant prior knowledge before proceeding.
+
+# Skill Capture
+
+When the user says "skill this", "make this a skill", or "save this as a skill" — write a fleeting note to `~/second-brain/Inbox/` describing the workflow as a skill candidate:
+
+1. Use the same filename format as second brain notes: `YYYYMMDD-HHMMSS-skill-slug.md`
+2. Tag it `tags: [skill-candidate]`
+3. Describe what the skill does, when to trigger it, and the key steps — based on what actually happened in the session
+4. During `/curate`, skill candidates get reviewed and promoted to macfair's `files/claude/skills/`
+
+# Skill Usage Tracking
+
+When invoking a user-invocable skill (via `/skill-name`), append a usage entry to `~/.claude/MEMORY/State/skills-usage.log`:
+```text
+YYYY-MM-DD skill-name
+```
+This log is reviewed during curate sessions to identify active vs dead skills.
 
 # Recovery & Steering
 

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -48,20 +48,18 @@ trim () {
 }
 
 aud () {
-  mkdir -p "$HOME/videos/transcripts"
-  yt-dlp --cookies-from-browser safari -xiwc --write-auto-sub --sub-lang en -o "$HOME/videos/%(title)s.%(ext)s" "$1"
-  find "$HOME/videos" -maxdepth 1 -name "*.vtt" -exec mv {} "$HOME/videos/transcripts/" \;
+  mkdir -p "$HOME/videos/media" "$HOME/videos/transcripts"
+  yt-dlp --cookies-from-browser firefox -xiwc --write-auto-sub --sub-lang en -o "$HOME/videos/media/%(title)s.%(ext)s" -o "subtitle:$HOME/videos/transcripts/%(title)s.%(ext)s" "$1"
 }
 
 tune () {
   mkdir -p "$HOME/mp3"
-  yt-dlp --cookies-from-browser safari -xiwc --audio-format mp3 -o "$HOME/mp3/%(title)s.%(ext)s" "$1"
+  yt-dlp --cookies-from-browser firefox -xiwc --audio-format mp3 -o "$HOME/mp3/%(title)s.%(ext)s" "$1"
 }
 
 vid () {
-  mkdir -p "$HOME/videos/transcripts"
-  yt-dlp --cookies-from-browser safari --write-auto-sub --sub-lang en -o "$HOME/videos/%(title)s.%(ext)s" "$1"
-  find "$HOME/videos" -maxdepth 1 -name "*.vtt" -exec mv {} "$HOME/videos/transcripts/" \;
+  mkdir -p "$HOME/videos/media" "$HOME/videos/transcripts"
+  yt-dlp --cookies-from-browser firefox --write-auto-sub --sub-lang en -o "$HOME/videos/media/%(title)s.%(ext)s" -o "subtitle:$HOME/videos/transcripts/%(title)s.%(ext)s" "$1"
 }
 
 help() {


### PR DESCRIPTION
add skill capture workflow and update yt-dlp config

- Add skill capture and usage tracking sections to Claude config
- Add insight capture step (step 11) to commit workflow
- Switch yt-dlp cookies from Safari to Firefox
- Organize video downloads into videos/media/ subdirectory
- Add parallel subagents instruction for multi-file tasks
- Enhance second brain notes with WHY guidance and prior knowledge search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insight capture workflow for saving session insights
  * Skill capture and usage-tracking for reusable workflows
  * Guideline to use parallel subagents for tasks touching 3+ independent areas

* **Documentation**
  * Stronger note-taking guidance to record WHY decisions matter
  * Proactive knowledge-reuse guidance and expanded recovery/steering advice

* **Chores**
  * Updated command behavior to organize media/transcripts and use Firefox cookies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->