### PR TITLE
gh-532: unalias gbr

### DIFF
--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -1,3 +1,5 @@
+unalias gbr 2>/dev/null
+
 gitundo () { # Undo last git operation (safe: fails if uncommitted changes conflict)
   [[ ! -d .git ]] && echo "Not a git repo" && return 1
   local current=$(git rev-parse --short HEAD)


### PR DESCRIPTION
unalias gbr before function definition to avoid zsh parse error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of git alias initialization to safely handle cases where aliases may not already be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->