### PR TITLE
device and hydrate

### DIFF
--- a/files/bin/macropad_action
+++ b/files/bin/macropad_action
@@ -1,0 +1,17 @@
+#!/bin/bash
+case "$1" in
+  typeA)
+    app=$(osascript -e 'tell application "System Events" to get name of first process whose frontmost is true')
+    case "$app" in
+      wezterm|WezTerm)
+        /Applications/WezTerm.app/Contents/MacOS/wezterm cli send-text --no-paste "A"
+        ;;
+      iTerm2)
+        osascript -e 'tell application "iTerm2" to tell current session of current window to write text "A" without newline'
+        ;;
+    esac
+    ;;
+  wezterm) /Applications/WezTerm.app/Contents/MacOS/wezterm start & ;;
+  browser) open -a Safari ;;
+  lock) pmset displaysleepnow ;;
+esac

--- a/files/bin/whisper_wrapper
+++ b/files/bin/whisper_wrapper
@@ -90,6 +90,11 @@ stop_recording() {
   echo $! > "$MONITOR_PID_FILE"
 }
 
+[[ -f "$STATE_FILE" ]] && {
+  local_age=$(( $(date +%s) - $(stat -f %m "$STATE_FILE") ))
+  (( local_age > 300 )) && rm -f "$STATE_FILE"
+}
+
 if [[ -f "$STATE_FILE" ]]; then
   stop_recording
 else

--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -119,56 +119,6 @@
             ]
           },
           {
-            "description": "F18: Toggle whisper recording (macro pad key 1)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "f18",
-                  "modifiers": { "optional": ["any"] }
-                },
-                "to": [
-                  {
-                    "shell_command": "/usr/local/bin/whisper_wrapper"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": "F17: Enter/submit (macro pad key 2)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "f17",
-                  "modifiers": { "optional": ["any"] }
-                },
-                "to": [
-                  { "key_code": "return_or_enter" }
-                ]
-              }
-            ]
-          },
-          {
-            "description": "F16: Ctrl+C interrupt (macro pad key 3)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "f16",
-                  "modifiers": { "optional": ["any"] }
-                },
-                "to": [
-                  {
-                    "key_code": "c",
-                    "modifiers": ["control"]
-                  }
-                ]
-              }
-            ]
-          },
-          {
             "description": "Ctrl+N: New WezTerm window in current space",
             "manipulators": [
               {
@@ -186,22 +136,368 @@
             ]
           },
           {
-            "description": "F15: Escape (macro pad key 4)",
+            "description": "KM16 Pro: 1 — /speak + start whisper",
             "manipulators": [
               {
                 "type": "basic",
                 "from": {
-                  "key_code": "f15",
+                  "key_code": "1",
                   "modifiers": { "optional": ["any"] }
                 },
                 "to": [
-                  { "key_code": "escape" }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"/speak \"'; /usr/local/bin/whisper_wrapper" }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 3 — Whisper toggle",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "3",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/whisper_wrapper"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 2 — Whisper + auto-submit",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "2",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/whisper_wrapper --submit"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 5 — Jump to Desktop 5",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "5",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to key code 23 using {control down}'"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 6 — Open Linear",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "6",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "open -a Linear"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 4 — Lock screen",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "4",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/macropad_action lock"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 7 — Open Slack",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "7",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "open -a Slack"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 8 — Ctrl+C interrupt",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "8",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "key_code": "c",
+                    "modifiers": ["control"]
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 9 — New WezTerm window",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "9",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/macropad_action wezterm"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: 0 — Jump to Desktop 16",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "0",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to key code 16 using {control down}'"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: up_arrow — Open/focus browser",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "up_arrow",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "/usr/local/bin/macropad_action browser"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: left_arrow — Previous desktop",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "left_arrow",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "key_code": "left_arrow",
+                    "modifiers": ["control"]
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: down_arrow — Jump to Desktop 1",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "down_arrow",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "shell_command": "osascript -e 'tell application \"System Events\" to key code 18 using {control down}'"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 Pro: right_arrow — Next desktop",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "right_arrow",
+                  "modifiers": { "optional": ["any"] }
+                },
+                "to": [
+                  {
+                    "key_code": "right_arrow",
+                    "modifiers": ["control"]
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
+                  }
                 ]
               }
             ]
           }
         ]
-      }
+      },
+      "devices": [
+        {
+          "identifiers": {
+            "is_keyboard": true,
+            "is_pointing_device": true,
+            "product_id": 12613,
+            "vendor_id": 10473
+          },
+          "ignore": false
+        },
+        {
+          "identifiers": {
+            "is_keyboard": true,
+            "is_pointing_device": false,
+            "product_id": 12613,
+            "vendor_id": 10473
+          },
+          "ignore": false
+        },
+        {
+          "identifiers": {
+            "is_keyboard": true,
+            "is_pointing_device": false,
+            "product_id": 8192,
+            "vendor_id": 10473
+          },
+          "ignore": false
+        },
+        {
+          "identifiers": {
+            "is_keyboard": true,
+            "is_pointing_device": false,
+            "product_id": 49271,
+            "vendor_id": 1389
+          },
+          "ignore": false
+        }
+      ]
     }
   ]
 }

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -20,6 +20,13 @@
     mode: '0755'
   become: true
 
+- name: Copy macropad action script
+  ansible.builtin.copy:
+    src: bin/macropad_action
+    dest: /usr/local/bin/macropad_action
+    mode: '0755'
+  become: true
+
 - name: Create whisper cues directory
   ansible.builtin.file:
     path: "{{ ['~' + macbook_user.stdout, '.local', 'share', 'whisper_cues'] | path_join }}"


### PR DESCRIPTION
## Why



## What changed

update KM16 Pro macropad rules for actual keycodes and wireless
- Replace F14-F18 Karabiner rules with actual keycode mappings (1-0, arrows)
- Support USB, Bluetooth, and 2.4G wireless device IDs in all rules
- Add device entries to persist Modify Events across Karabiner restarts
- Use osascript for /speak keystroke to avoid phantom shift on wireless
- Add macropad_action script and ansible task to deploy it
- Add stale state file cleanup to whisper_wrapper (5min timeout)
- Remap key layout: whisper trio on top row, desktop/app switching on rows 2-3

## How to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KM16 Pro keyboard support with labeled macro mappings for numeric keys (1–9, 0)
  * Context-aware macro action to send app-specific keystrokes and launch apps
* **Bug Fixes**
  * Stale-state cleanup to make audio recording/start-stop more reliable
* **Chores**
  * Installation step added to deploy the macropad action script system-wide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->