### PR TITLE
cl whisper autolaunch

### DIFF
--- a/files/bin/whisper_wrapper
+++ b/files/bin/whisper_wrapper
@@ -15,8 +15,19 @@ CUE_DIR="$HOME/.local/share/whisper_cues"
 SW_DB="$HOME/Library/Application Support/ru.starmel.OpenSuperWhisper/recordings.sqlite"
 
 pgrep -f "OpenSuperWhisper" >/dev/null 2>&1 || {
-  afplay /System/Library/Sounds/Basso.aiff &
-  exit 1
+  afplay "$CUE_DIR/starting.aiff" &
+  open -a OpenSuperWhisper
+  max=20; i=0
+  while (( i < max )); do
+    sleep 0.5
+    pgrep -f "OpenSuperWhisper" >/dev/null 2>&1 && break
+    i=$(( i + 1 ))
+  done
+  pgrep -f "OpenSuperWhisper" >/dev/null 2>&1 || {
+    afplay /System/Library/Sounds/Basso.aiff &
+    exit 1
+  }
+  sleep 2
 }
 
 play_cue() {

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -42,6 +42,7 @@
     - listening
     - transcribing
     - done
+    - starting
   when: inventory_hostname != 'github-runner.localhost'
 
 - name: Copy WezTerm config


### PR DESCRIPTION
## Why



## What changed

auto-launch OpenSuperWhisper when whisper_wrapper is triggered
- Play "starting" cue and launch OSW if not running, wait up to 10s
- 2s settle delay after process detected for hotkey listener readiness
- Fall back to error sound if OSW fails to start
- Add "starting" to ansible cue generation loop

## How to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup audio cue feedback when launching the application.

* **Improvements**
  * Enhanced application startup robustness with improved process initialization handling and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->