### PR TITLE
gh-545: km16 layers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: conventional Changelog Action
         id: changelog
@@ -41,7 +41,7 @@ jobs:
   #     DEPLOY_URL: macfair.io37.ch
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #
   #     - name: make a gitconfig
   #       run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -15,10 +15,10 @@ jobs:
       STAGING_URL: asda.io37.ch
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Syntax-check ZSH files
         run: |
@@ -107,7 +107,7 @@ jobs:
           exit $failed
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -136,324 +136,353 @@
             ]
           },
           {
-            "description": "KM16 Pro: 1 — /speak + start whisper",
+            "description": "KM16 L1: 1 — Open Vivaldi → return",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "1",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "1", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "open -a Vivaldi" },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L1: 2 — Open Firefox → return",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "2", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "open -a Firefox" },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L1: 3 — Open Safari → return",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "3", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "open -a Safari" },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L1: 4 — Open Linear → return",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "4", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "open -a Linear" },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L1: 5 — Open Slack → return",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "5", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "open -a Slack" },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L1: 6 — Open Obsidian → return",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "6", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "open -a Obsidian" },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L1: 0 — Ctrl+C interrupt → return",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "0", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "key_code": "c", "modifiers": ["control"] },
+                  { "set_variable": { "name": "km16_layer", "value": 0 } }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 1 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L0: 1 — /speak + start whisper",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "1", "modifiers": { "optional": ["any"] } },
                 "to": [
                   { "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"/speak \"'; /usr/local/bin/whisper_wrapper" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 3 — Whisper toggle",
+            "description": "KM16 L0: 2 — Whisper toggle",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "3",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "2", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "/usr/local/bin/whisper_wrapper"
-                  }
+                  { "shell_command": "/usr/local/bin/whisper_wrapper" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 2 — Whisper + auto-submit",
+            "description": "KM16 L0: 3 — /commit",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "2",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "3", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "/usr/local/bin/whisper_wrapper --submit"
-                  }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"/commit\"' -e 'tell application \"System Events\" to key code 36'" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 5 — Jump to Desktop 5",
+            "description": "KM16 L0: 4 — Enter Layer 1 (app launcher, 5s timeout, to_if_canceled must be empty)",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "5",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "4", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to key code 23 using {control down}'"
-                  }
+                  { "set_variable": { "name": "km16_layer", "value": 1 } }
                 ],
+                "to_delayed_action": {
+                  "to_if_invoked": [
+                    { "set_variable": { "name": "km16_layer", "value": 0 } }
+                  ],
+                  "to_if_canceled": []
+                },
+                "parameters": {
+                  "basic.to_delayed_action_delay_milliseconds": 5000
+                },
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 6 — Open Linear",
+            "description": "KM16 L0: 5 — Focus WezTerm",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "6",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "5", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "open -a Linear"
-                  }
+                  { "shell_command": "open -a WezTerm" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 4 — Lock screen",
+            "description": "KM16 L0: 6 — Cycle WezTerm pane",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "4",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "6", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "/usr/local/bin/macropad_action lock"
-                  }
+                  { "shell_command": "/Applications/WezTerm.app/Contents/MacOS/wezterm cli activate-pane-direction Next" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 7 — Open Slack",
+            "description": "KM16 L0: 7 — Cycle app windows (⌘`)",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "7",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "7", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "open -a Slack"
-                  }
+                  { "key_code": "grave_accent_and_tilde", "modifiers": ["command"] }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 8 — Ctrl+C interrupt",
+            "description": "KM16 L0: 8 — New WezTerm window",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "8",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "8", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "key_code": "c",
-                    "modifiers": ["control"]
-                  }
+                  { "shell_command": "/usr/local/bin/macropad_action wezterm" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 9 — New WezTerm window",
+            "description": "KM16 L0: 9 — Jump to Desktop 9",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "9",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "9", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "/usr/local/bin/macropad_action wezterm"
-                  }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to key code 25 using {control down}'" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: 0 — Jump to Desktop 16",
+            "description": "KM16 L0: 0 — /clear",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "0",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "0", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to key code 16 using {control down}'"
-                  }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to keystroke \"/clear\"' -e 'tell application \"System Events\" to key code 36'" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: up_arrow — Open/focus browser",
+            "description": "KM16 L0: up_arrow — Jump to Desktop 16",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "up_arrow",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "up_arrow", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "/usr/local/bin/macropad_action browser"
-                  }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to key code 16 using {control down}'" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: left_arrow — Previous desktop",
+            "description": "KM16 L0: left_arrow — Previous desktop",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "left_arrow",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "left_arrow", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "key_code": "left_arrow",
-                    "modifiers": ["control"]
-                  }
+                  { "key_code": "left_arrow", "modifiers": ["control"] }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: down_arrow — Jump to Desktop 1",
+            "description": "KM16 L0: down_arrow — Jump to Desktop 1",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "down_arrow",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "down_arrow", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "shell_command": "osascript -e 'tell application \"System Events\" to key code 18 using {control down}'"
-                  }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to key code 18 using {control down}'" }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]
           },
           {
-            "description": "KM16 Pro: right_arrow — Next desktop",
+            "description": "KM16 L0: right_arrow — Next desktop",
             "manipulators": [
               {
                 "type": "basic",
-                "from": {
-                  "key_code": "right_arrow",
-                  "modifiers": { "optional": ["any"] }
-                },
+                "from": { "key_code": "right_arrow", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  {
-                    "key_code": "right_arrow",
-                    "modifiers": ["control"]
-                  }
+                  { "key_code": "right_arrow", "modifiers": ["control"] }
                 ],
                 "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }]
-                  }
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
                 ]
               }
             ]

--- a/files/km16/generate.py
+++ b/files/km16/generate.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Generate KM16 Pro infographic from karabiner.json rules."""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+KARABINER = Path(__file__).parent.parent / "karabiner" / "karabiner.json"
+OUTPUT = Path(__file__).parent / "index.html"
+
+PHYSICAL_LAYOUT = [
+    ["1", "2", "3", "4"],
+    ["5", "6", "7", "8"],
+    ["9", "0", "up_arrow", "return_or_enter"],
+    ["fn", "left_arrow", "down_arrow", "right_arrow"],
+]
+
+DISPLAY_LABELS = {
+    "up_arrow": "&uarr;",
+    "down_arrow": "&darr;",
+    "left_arrow": "&larr;",
+    "right_arrow": "&rarr;",
+    "return_or_enter": "Enter",
+    "fn": "Fn",
+}
+
+FRIENDLY = {
+    "/speak + start whisper": ("/speak", "+ whisper"),
+    "Whisper toggle": ("Whisper", "toggle"),
+    "/commit": ("/commit", None),
+    "/clear": ("/clear", None),
+    "Focus WezTerm": ("WezTerm", "focus"),
+    "Cycle WezTerm pane": ("Cycle", "pane"),
+    "Cycle app windows (⌘`)": ("Cycle", "windows"),
+    "New WezTerm window": ("WezTerm", "new window"),
+    "Jump to Desktop 9": ("Desktop", "9"),
+    "Jump to Desktop 16": ("Desktop", "16"),
+    "Jump to Desktop 1": ("Desktop", "1"),
+    "Previous desktop": ("Prev", "desktop"),
+    "Next desktop": ("Next", "desktop"),
+    "Ctrl+C interrupt → return": ("Ctrl+C", None),
+    "Open Vivaldi → return": ("Vivaldi", None),
+    "Open Firefox → return": ("Firefox", None),
+    "Open Safari → return": ("Safari", None),
+    "Open Linear → return": ("Linear", None),
+    "Open Slack → return": ("Slack", None),
+    "Open Obsidian → return": ("Obsidian", None),
+}
+
+LAYER_TOGGLE_RE = re.compile(r"Enter Layer 1")
+
+
+def parse_rules(path):
+    with open(path) as f:
+        config = json.load(f)
+
+    layers = {0: {}, 1: {}}
+    layer_toggle_key = None
+
+    for profile in config.get("profiles", []):
+        for rule in profile.get("complex_modifications", {}).get("rules", []):
+            desc = rule.get("description", "")
+            m = re.match(r"KM16 L(\d): (.+?) — (.+)", desc)
+            if not m:
+                continue
+            layer = int(m.group(1))
+            key = m.group(2)
+            action = m.group(3)
+
+            if LAYER_TOGGLE_RE.search(action):
+                layer_toggle_key = key
+
+            layers[layer][key] = action
+
+    return layers, layer_toggle_key
+
+
+def render_key_l0(key, label, action, is_toggle):
+    if key in ("return_or_enter", "fn"):
+        if key == "fn":
+            return (
+                '          <div class="bg-black text-cream/30 border-4 border-black/30 '
+                'p-4 aspect-square flex flex-col justify-between">\n'
+                f'            <span class="text-xs">{label}</span>\n'
+                '            <p class="text-xs italic">firmware</p>\n'
+                '          </div>'
+            )
+        return (
+            '          <div class="bg-black text-cream/30 border-4 border-black/30 '
+            'p-4 aspect-square flex flex-col justify-between">\n'
+            f'            <span class="text-xs">{label}</span>\n'
+            '            <p class="text-xs italic">enter</p>\n'
+            '          </div>'
+        )
+
+    if is_toggle:
+        title, subtitle = "Layer 1", "app launcher"
+        return (
+            '          <div class="bg-black text-gold border-4 border-gold '
+            'p-4 aspect-square flex flex-col justify-between">\n'
+            f'            <span class="text-xs text-gold/50">{label}</span>\n'
+            '            <div>\n'
+            f'              <p class="text-sm font-bold">{title}</p>\n'
+            f'              <p class="text-xs text-gold/60">{subtitle}</p>\n'
+            '            </div>\n'
+            '          </div>'
+        )
+
+    if not action:
+        return (
+            '          <div class="bg-black text-cream/30 border-4 border-black/30 '
+            'p-4 aspect-square flex flex-col justify-between">\n'
+            f'            <span class="text-xs">{label}</span>\n'
+            '            <p class="text-xs italic">unmapped</p>\n'
+            '          </div>'
+        )
+
+    title, subtitle = FRIENDLY.get(action, (action, None))
+    sub_html = ""
+    if subtitle:
+        sub_html = f'\n              <p class="text-xs text-cream/60">{subtitle}</p>'
+
+    return (
+        '          <div class="bg-black text-cream border-4 border-black '
+        'p-4 aspect-square flex flex-col justify-between">\n'
+        f'            <span class="text-xs text-cream/50">{label}</span>\n'
+        '            <div>\n'
+        f'              <p class="text-sm font-bold">{title}</p>{sub_html}\n'
+        '            </div>\n'
+        '          </div>'
+    )
+
+
+def render_key_l1(key, label, action):
+    if key in ("return_or_enter", "fn"):
+        cls = "bg-cream text-black/30 border-4 border-black/10"
+        inner = "firmware" if key == "fn" else "unmapped"
+        return (
+            f'          <div class="{cls} '
+            'p-4 aspect-square flex flex-col justify-between">\n'
+            f'            <span class="text-xs">{label}</span>\n'
+            f'            <p class="text-xs italic">{inner}</p>\n'
+            '          </div>'
+        )
+
+    if not action:
+        return (
+            '          <div class="bg-cream text-black/30 border-4 border-black/10 '
+            'p-4 aspect-square flex flex-col justify-between">\n'
+            f'            <span class="text-xs">{label}</span>\n'
+            '            <p class="text-xs italic">unmapped</p>\n'
+            '          </div>'
+        )
+
+    title, subtitle = FRIENDLY.get(action, (action, None))
+    sub_html = ""
+    if subtitle:
+        sub_html = f'\n              <p class="text-xs text-black/60">{subtitle}</p>'
+
+    return (
+        '          <div class="bg-pink text-black border-4 border-red '
+        'p-4 aspect-square flex flex-col justify-between">\n'
+        f'            <span class="text-xs text-black/40">{label}</span>\n'
+        '            <div>\n'
+        f'              <p class="text-sm font-bold">{title}</p>{sub_html}\n'
+        '            </div>\n'
+        '          </div>'
+    )
+
+
+def render_grid(layer_data, layer_num, toggle_key):
+    keys = []
+    for row in PHYSICAL_LAYOUT:
+        for key in row:
+            label = DISPLAY_LABELS.get(key, key)
+            action = layer_data.get(key) or layer_data.get(label)
+            is_toggle = layer_num == 0 and key == toggle_key
+            if layer_num == 0:
+                keys.append(render_key_l0(key, label, action, is_toggle))
+            else:
+                keys.append(render_key_l1(key, label, action))
+    return "\n".join(keys)
+
+
+def generate(layers, toggle_key):
+    now = datetime.now().strftime("%-d %B %Y")
+    l0_grid = render_grid(layers[0], 0, toggle_key)
+    l1_grid = render_grid(layers[1], 1, toggle_key)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KM16 Pro Key Map</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {{
+      --cream: #f5f3e8;
+      --black: #222;
+      --red: #db5439;
+      --pink: rgba(220, 84, 57, 0.5);
+      --gold: #eebe6d;
+    }}
+  </style>
+  <script>
+    tailwind.config = {{
+      theme: {{
+        fontFamily: {{
+          serif: ['"Libre Baskerville"', 'Georgia', 'serif'],
+        }},
+        extend: {{
+          colors: {{
+            cream: 'var(--cream)',
+            black: 'var(--black)',
+            red: 'var(--red)',
+            pink: 'var(--pink)',
+            gold: 'var(--gold)',
+          }}
+        }}
+      }}
+    }}
+  </script>
+</head>
+<body class="bg-cream text-black font-serif min-h-screen">
+  <div class="max-w-4xl mx-auto px-8 py-16">
+    <header class="mb-12">
+      <h1 class="text-2xl font-bold uppercase tracking-wide">KM16 Pro Key Map</h1>
+      <p class="text-sm mt-2 italic text-black/70">Software layers via Karabiner Elements. Key {toggle_key} enters Layer 1; actions auto-return to Layer 0. 5s timeout.</p>
+    </header>
+
+    <main>
+      <section class="mb-12">
+        <h2 class="text-lg font-bold uppercase tracking-wide mb-6">Layer 0 <span class="text-xs font-bold bg-gold text-black px-2 py-1 ml-2">Default</span></h2>
+        <div class="grid grid-cols-4 gap-3">
+{l0_grid}
+        </div>
+      </section>
+
+      <hr class="my-8 border-black">
+
+      <section class="mb-12">
+        <h2 class="text-lg font-bold uppercase tracking-wide mb-6">Layer 1 <span class="text-xs font-bold bg-red text-cream px-2 py-1 ml-2">App Launcher</span></h2>
+        <div class="border-l-4 border-red pl-4 mb-6 py-2 pr-4">
+          <p class="text-sm italic">Press key {toggle_key} to enter. Each action auto-returns to Layer 0. Times out after 5 seconds.</p>
+        </div>
+        <div class="grid grid-cols-4 gap-3">
+{l1_grid}
+        </div>
+      </section>
+
+      <hr class="my-8 border-black">
+
+      <section>
+        <h2 class="text-lg font-bold uppercase tracking-wide mb-4">Connection</h2>
+        <dl class="space-y-2 text-sm">
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 1</dt>
+            <dd>Bluetooth 1</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 2</dt>
+            <dd>Bluetooth 2 (pairing)</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 3</dt>
+            <dd>Bluetooth 3</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 4</dt>
+            <dd>2.4G dongle</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">USB cable</dt>
+            <dd>Charge only (data not working)</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Big button</dt>
+            <dd>Hardware layer cycle (LED color, no keycode sent)</dd>
+          </div>
+        </dl>
+      </section>
+    </main>
+
+    <footer class="mt-16 pt-8 border-t border-black/20 text-sm text-black/60">
+      Generated {now}
+    </footer>
+  </div>
+</body>
+</html>
+"""
+
+
+def main():
+    src = Path(sys.argv[1]) if len(sys.argv) > 1 else KARABINER
+    layers, toggle_key = parse_rules(src)
+    html = generate(layers, toggle_key)
+    OUTPUT.write_text(html)
+    print(f"Generated {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/files/km16/index.html
+++ b/files/km16/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KM16 Pro Key Map</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&display=swap">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --cream: #f5f3e8;
+      --black: #222;
+      --red: #db5439;
+      --pink: rgba(220, 84, 57, 0.5);
+      --gold: #eebe6d;
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      theme: {
+        fontFamily: {
+          serif: ['"Libre Baskerville"', 'Georgia', 'serif'],
+        },
+        extend: {
+          colors: {
+            cream: 'var(--cream)',
+            black: 'var(--black)',
+            red: 'var(--red)',
+            pink: 'var(--pink)',
+            gold: 'var(--gold)',
+          }
+        }
+      }
+    }
+  </script>
+</head>
+<body class="bg-cream text-black font-serif min-h-screen">
+  <div class="max-w-4xl mx-auto px-8 py-16">
+    <header class="mb-12">
+      <h1 class="text-2xl font-bold uppercase tracking-wide">KM16 Pro Key Map</h1>
+      <p class="text-sm mt-2 italic text-black/70">Software layers via Karabiner Elements. Key 4 enters Layer 1; actions auto-return to Layer 0. 5s timeout.</p>
+    </header>
+
+    <main>
+      <section class="mb-12">
+        <h2 class="text-lg font-bold uppercase tracking-wide mb-6">Layer 0 <span class="text-xs font-bold bg-gold text-black px-2 py-1 ml-2">Default</span></h2>
+        <div class="grid grid-cols-4 gap-3">
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">1</span>
+            <div>
+              <p class="text-sm font-bold">/speak</p>
+              <p class="text-xs text-cream/60">+ whisper</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">2</span>
+            <div>
+              <p class="text-sm font-bold">Whisper</p>
+              <p class="text-xs text-cream/60">toggle</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">3</span>
+            <div>
+              <p class="text-sm font-bold">/commit</p>
+            </div>
+          </div>
+          <div class="bg-black text-gold border-4 border-gold p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-gold/50">4</span>
+            <div>
+              <p class="text-sm font-bold">Layer 1</p>
+              <p class="text-xs text-gold/60">app launcher</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">5</span>
+            <div>
+              <p class="text-sm font-bold">WezTerm</p>
+              <p class="text-xs text-cream/60">focus</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">6</span>
+            <div>
+              <p class="text-sm font-bold">Cycle</p>
+              <p class="text-xs text-cream/60">pane</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">7</span>
+            <div>
+              <p class="text-sm font-bold">Cycle</p>
+              <p class="text-xs text-cream/60">windows</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">8</span>
+            <div>
+              <p class="text-sm font-bold">WezTerm</p>
+              <p class="text-xs text-cream/60">new window</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">9</span>
+            <div>
+              <p class="text-sm font-bold">Desktop</p>
+              <p class="text-xs text-cream/60">9</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">0</span>
+            <div>
+              <p class="text-sm font-bold">/clear</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">&uarr;</span>
+            <div>
+              <p class="text-sm font-bold">Desktop</p>
+              <p class="text-xs text-cream/60">16</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream/30 border-4 border-black/30 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">Enter</span>
+            <p class="text-xs italic">enter</p>
+          </div>
+          <div class="bg-black text-cream/30 border-4 border-black/30 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">Fn</span>
+            <p class="text-xs italic">firmware</p>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">&larr;</span>
+            <div>
+              <p class="text-sm font-bold">Prev</p>
+              <p class="text-xs text-cream/60">desktop</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">&darr;</span>
+            <div>
+              <p class="text-sm font-bold">Desktop</p>
+              <p class="text-xs text-cream/60">1</p>
+            </div>
+          </div>
+          <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-cream/50">&rarr;</span>
+            <div>
+              <p class="text-sm font-bold">Next</p>
+              <p class="text-xs text-cream/60">desktop</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <hr class="my-8 border-black">
+
+      <section class="mb-12">
+        <h2 class="text-lg font-bold uppercase tracking-wide mb-6">Layer 1 <span class="text-xs font-bold bg-red text-cream px-2 py-1 ml-2">App Launcher</span></h2>
+        <div class="border-l-4 border-red pl-4 mb-6 py-2 pr-4">
+          <p class="text-sm italic">Press key 4 to enter. Each action auto-returns to Layer 0. Times out after 5 seconds.</p>
+        </div>
+        <div class="grid grid-cols-4 gap-3">
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">1</span>
+            <div>
+              <p class="text-sm font-bold">Vivaldi</p>
+            </div>
+          </div>
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">2</span>
+            <div>
+              <p class="text-sm font-bold">Firefox</p>
+            </div>
+          </div>
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">3</span>
+            <div>
+              <p class="text-sm font-bold">Safari</p>
+            </div>
+          </div>
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">4</span>
+            <div>
+              <p class="text-sm font-bold">Linear</p>
+            </div>
+          </div>
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">5</span>
+            <div>
+              <p class="text-sm font-bold">Slack</p>
+            </div>
+          </div>
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">6</span>
+            <div>
+              <p class="text-sm font-bold">Obsidian</p>
+            </div>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">7</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">8</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">9</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-pink text-black border-4 border-red p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs text-black/40">0</span>
+            <div>
+              <p class="text-sm font-bold">Ctrl+C</p>
+            </div>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">&uarr;</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">Enter</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">Fn</span>
+            <p class="text-xs italic">firmware</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">&larr;</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">&darr;</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+          <div class="bg-cream text-black/30 border-4 border-black/10 p-4 aspect-square flex flex-col justify-between">
+            <span class="text-xs">&rarr;</span>
+            <p class="text-xs italic">unmapped</p>
+          </div>
+        </div>
+      </section>
+
+      <hr class="my-8 border-black">
+
+      <section>
+        <h2 class="text-lg font-bold uppercase tracking-wide mb-4">Connection</h2>
+        <dl class="space-y-2 text-sm">
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 1</dt>
+            <dd>Bluetooth 1</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 2</dt>
+            <dd>Bluetooth 2 (pairing)</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 3</dt>
+            <dd>Bluetooth 3</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Fn + 4</dt>
+            <dd>2.4G dongle</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">USB cable</dt>
+            <dd>Charge only (data not working)</dd>
+          </div>
+          <div class="flex gap-4">
+            <dt class="font-semibold min-w-32">Big button</dt>
+            <dd>Hardware layer cycle (LED color, no keycode sent)</dd>
+          </div>
+        </dl>
+      </section>
+    </main>
+
+    <footer class="mt-16 pt-8 border-t border-black/20 text-sm text-black/60">
+      Generated 22 March 2026
+    </footer>
+  </div>
+</body>
+</html>

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -136,6 +136,11 @@
     dest: "{{ [ansible_env.HOME, '.config', 'karabiner', 'karabiner.json'] | path_join }}"
     force: yes
 
+- name: Generate KM16 infographic
+  ansible.builtin.command:
+    cmd: python3 files/km16/generate.py
+    chdir: "{{ playbook_dir }}"
+
 - name: Install/update GSD (always runs for latest)
   ansible.builtin.command: npx get-shit-done-cc@latest --global
   environment:


### PR DESCRIPTION
## Why



## What changed

implement KM16 software layers via Karabiner
- Add Layer 0 and Layer 1 with km16_layer variable switching
- Layer 1 as app launcher: Vivaldi, Firefox, Safari, Linear, Slack, Obsidian
- Remap Layer 0 keys: /speak, whisper, /commit, /clear, WezTerm focus/pane/window cycling
- Add 5s timeout auto-reset for Layer 1
- Add KM16 infographic page

## How to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-layer KM16 Pro keyboard: Layer 0 for whisper/speech, terminal navigation and desktop switching; Layer 1 as an app launcher (Vivaldi, Firefox, Safari, Linear, Slack, Obsidian).
* **Documentation**
  * Added a visual KM16 keymap infographic (static HTML) showing both layers and connection mappings.
* **Chores**
  * Playbook now runs the infographic generator as part of the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->