### PR TITLE
gh-549: wezterm focus issue

### DIFF
--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -334,7 +334,7 @@
                 "type": "basic",
                 "from": { "key_code": "5", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  { "shell_command": "open -a WezTerm" }
+                  { "shell_command": "osascript -e 'tell application \"System Events\" to set frontmost of process \"wezterm-gui\" to true'" }
                 ],
                 "conditions": [
                   { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },


### PR DESCRIPTION
## Why



## What changed

KM16 key 5 focuses existing WezTerm instead of opening new window

## How to test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Modified the keyboard shortcut mechanism for focusing WezTerm, implementing an alternative invocation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->