### PR TITLE
gh-552: nvim lua

### DIFF
--- a/files/km16/generate.py
+++ b/files/km16/generate.py
@@ -4,7 +4,6 @@
 import json
 import re
 import sys
-from datetime import datetime
 from pathlib import Path
 
 KARABINER = Path(__file__).parent.parent / "karabiner" / "karabiner.json"
@@ -185,7 +184,6 @@ def render_grid(layer_data, layer_num, toggle_key):
 
 
 def generate(layers, toggle_key):
-    now = datetime.now().strftime("%-d %B %Y")
     l0_grid = render_grid(layers[0], 0, toggle_key)
     l1_grid = render_grid(layers[1], 1, toggle_key)
 
@@ -288,7 +286,7 @@ def generate(layers, toggle_key):
     </main>
 
     <footer class="mt-16 pt-8 border-t border-black/20 text-sm text-black/60">
-      Generated {now}
+      KM16 Pro Key Reference
     </footer>
   </div>
 </body>

--- a/files/km16/index.html
+++ b/files/km16/index.html
@@ -277,7 +277,7 @@
     </main>
 
     <footer class="mt-16 pt-8 border-t border-black/20 text-sm text-black/60">
-      Generated 22 March 2026
+      KM16 Pro Key Reference
     </footer>
   </div>
 </body>

--- a/files/wezterm.lua
+++ b/files/wezterm.lua
@@ -205,6 +205,7 @@ config.mouse_bindings = {
 }
 
 config.keys = {
+  { key = 'Enter', mods = 'SHIFT', action = wezterm.action.SendString '\x1b[13;2u' },
   { key = '|', mods = 'LEADER|SHIFT', action = wezterm.action.SplitHorizontal { domain = 'CurrentPaneDomain' } },
   { key = '-', mods = 'LEADER', action = wezterm.action.SplitVertical { domain = 'CurrentPaneDomain' } },
   { key = 'h', mods = 'LEADER', action = wezterm.action.ActivatePaneDirection 'Left' },

--- a/host_vars/kiseljak.localhost/vars.yml
+++ b/host_vars/kiseljak.localhost/vars.yml
@@ -1,3 +1,23 @@
 ansible_connection: local
 iterm_theme: "coffee"
 zsh_theme: "cerico-w-user"
+
+desktop_app_bindings:
+  - bundle_id: com.vivaldi.Vivaldi
+    desktop: 1
+  - bundle_id: org.mozilla.firefox
+    desktop: 2
+  - bundle_id: com.linear
+    desktop: 3
+  - bundle_id: com.tinyspeck.slackmacgap
+    desktop: 3
+  - bundle_id: md.obsidian
+    desktop: 4
+  - bundle_id: com.ableton.live
+    desktop: 15
+  - bundle_id: com.apple.finder
+    desktop: 16
+  - bundle_id: com.apple.Preview
+    desktop: 16
+  - bundle_id: com.apple.Safari
+    desktop: 16

--- a/roles/desktop/files/apply_app_bindings.py
+++ b/roles/desktop/files/apply_app_bindings.py
@@ -1,0 +1,24 @@
+import json
+import plistlib
+import subprocess
+import sys
+
+path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/app-bindings.json"
+
+with open(path) as f:
+    bindings = json.load(f)
+
+out = subprocess.run(["defaults", "export", "com.apple.spaces", "-"], capture_output=True)
+if out.returncode == 0:
+    plist = plistlib.loads(out.stdout)
+    current = plist.get("app-bindings", {})
+    if current == bindings:
+        print("unchanged")
+        sys.exit(0)
+
+cmd = ["defaults", "write", "com.apple.spaces", "app-bindings", "-dict"]
+for bundle_id, uuid in bindings.items():
+    cmd.extend([bundle_id, "-string", uuid])
+
+subprocess.run(cmd, check=True)
+print("changed")

--- a/roles/desktop/files/get_space_uuids.swift
+++ b/roles/desktop/files/get_space_uuids.swift
@@ -1,0 +1,32 @@
+import Cocoa
+
+@_silgen_name("CGSCopyManagedDisplaySpaces")
+func CGSCopyManagedDisplaySpaces(_ conn: Int32) -> CFArray?
+
+@_silgen_name("CGSMainConnectionID")
+func CGSMainConnectionID() -> Int32
+
+guard let info = CGSCopyManagedDisplaySpaces(CGSMainConnectionID()) as? [[String: Any]] else {
+    fputs("{}\n", stderr)
+    exit(1)
+}
+
+var result: [String: String] = [:]
+
+for display in info {
+    guard display["Display Identifier"] as? String == "Main",
+          let spaces = display["Spaces"] as? [[String: Any]] else { continue }
+    for (i, space) in spaces.enumerated() {
+        if let uuid = space["uuid"] as? String, !uuid.isEmpty {
+            result[String(i + 1)] = uuid
+        }
+    }
+}
+
+if let data = try? JSONSerialization.data(withJSONObject: result),
+   let json = String(data: data, encoding: .utf8) {
+    print(json)
+} else {
+    fputs("{}\n", stderr)
+    exit(1)
+}

--- a/roles/desktop/handlers/main.yml
+++ b/roles/desktop/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart dock
+  command: killall Dock

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -41,6 +41,22 @@
   changed_when: false
   when: wallpaper_files.files | length > 0
 
+- name: Create Karabiner config directory
+  file:
+    path: "{{ [ansible_env.HOME, '.config', 'karabiner'] | path_join }}"
+    state: directory
+
+- name: Copy Karabiner config
+  copy:
+    src: karabiner/karabiner.json
+    dest: "{{ [ansible_env.HOME, '.config', 'karabiner', 'karabiner.json'] | path_join }}"
+    force: yes
+
+- name: Generate KM16 infographic
+  ansible.builtin.command:
+    cmd: python3 files/km16/generate.py
+    chdir: "{{ playbook_dir }}"
+
 - name: Remove superfluous from dock
   shell: /usr/local/bin/dockutil --remove '{{ item }}' | cat
   ignore_errors: true
@@ -61,6 +77,40 @@
     - Reminders
     - App Store
     - System Preferences
+
+- name: Get space UUIDs for app bindings
+  script: files/get_space_uuids.swift
+  args:
+    executable: swift
+  register: space_uuids_raw
+  changed_when: false
+  failed_when: space_uuids_raw.rc != 0
+  when: desktop_app_bindings is defined and desktop_app_bindings | length > 0
+
+- name: Build app-bindings dict
+  set_fact:
+    app_bindings_dict: >-
+      {{ app_bindings_dict | default({}) | combine({
+        item.bundle_id: (space_uuids_raw.stdout | from_json)[item.desktop | string]
+      }) }}
+  loop: "{{ desktop_app_bindings }}"
+  when: desktop_app_bindings is defined and (space_uuids_raw.stdout | from_json)[item.desktop | string] is defined
+
+- name: Write app-bindings plist
+  copy:
+    content: "{{ app_bindings_dict | to_nice_json }}"
+    dest: "{{ ['/tmp', 'app-bindings.json'] | path_join }}"
+    mode: "0644"
+  when: app_bindings_dict is defined and app_bindings_dict | length > 0
+
+- name: Apply app-bindings to defaults
+  script: "files/apply_app_bindings.py {{ ['/tmp', 'app-bindings.json'] | path_join }}"
+  args:
+    executable: python3
+  register: apply_result
+  changed_when: "'changed' in apply_result.stdout"
+  when: app_bindings_dict is defined and app_bindings_dict | length > 0
+  notify: restart dock
 
 - name: print role name
   set_fact:

--- a/roles/functions/tasks/claude.yml
+++ b/roles/functions/tasks/claude.yml
@@ -73,22 +73,6 @@
     path: "{{ ['~' + macbook_user.stdout, '.claude', 'reports'] | path_join }}"
     state: directory
 
-- name: Create second brain vault directories
-  file:
-    path: "{{ ['~' + macbook_user.stdout, 'second-brain', item] | path_join }}"
-    state: directory
-  loop:
-    - Inbox
-    - Projects
-    - Areas
-    - Resources
-    - Archive
-    - Zettelkasten
-    - Literature
-    - MOCs
-    - Daily
-    - Templates
-
 - name: Create gemini directory
   file:
     path: "{{ ['~' + macbook_user.stdout, '.gemini'] | path_join }}"
@@ -98,17 +82,6 @@
   copy:
     src: claude/config.md
     dest: "{{ ['~' + macbook_user.stdout, '.gemini', 'GEMINI.md'] | path_join }}"
-
-- name: Install typescript-language-server for LSP plugin
-  community.general.npm:
-    name: "{{ item }}"
-    global: true
-    state: present
-  environment:
-    PATH: "/opt/homebrew/bin:/usr/local/bin:{{ ansible_env.HOME }}/.local/bin:{{ ansible_env.PATH }}"
-  loop:
-    - typescript-language-server
-    - typescript
 
 - name: Install Claude Code plugins from official marketplace
   ansible.builtin.shell: "claude plugin install {{ item }}@claude-plugins-official"
@@ -124,22 +97,6 @@
     - claude-code-setup
     - hookify
     - security-guidance
-
-- name: Create Karabiner config directory
-  file:
-    path: "{{ [ansible_env.HOME, '.config', 'karabiner'] | path_join }}"
-    state: directory
-
-- name: Copy Karabiner config
-  copy:
-    src: karabiner/karabiner.json
-    dest: "{{ [ansible_env.HOME, '.config', 'karabiner', 'karabiner.json'] | path_join }}"
-    force: yes
-
-- name: Generate KM16 infographic
-  ansible.builtin.command:
-    cmd: python3 files/km16/generate.py
-    chdir: "{{ playbook_dir }}"
 
 - name: Install/update GSD (always runs for latest)
   ansible.builtin.command: npx get-shit-done-cc@latest --global

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -1,4 +1,20 @@
 ---
+- name: Create second brain vault directories
+  file:
+    path: "{{ ['~' + macbook_user.stdout, 'second-brain', item] | path_join }}"
+    state: directory
+  loop:
+    - Inbox
+    - Projects
+    - Areas
+    - Resources
+    - Archive
+    - Zettelkasten
+    - Literature
+    - MOCs
+    - Daily
+    - Templates
+
 - name: Copy speak script
   ansible.builtin.copy:
     src: bin/speak
@@ -50,22 +66,12 @@
     src: wezterm.lua
     dest: "{{ ['~' + macbook_user.stdout, '.wezterm.lua'] | path_join }}"
 
-- name: Create neovim config directory
-  ansible.builtin.file:
-    path: "{{ ['~' + macbook_user.stdout, '.config', 'nvim'] | path_join }}"
-    state: directory
-
-- name: Copy neovim config
-  ansible.builtin.copy:
-    src: nvim/init.lua
-    dest: "{{ ['~' + macbook_user.stdout, '.config', 'nvim', 'init.lua'] | path_join }}"
-
-- name: Install gruvbox colorscheme for neovim
+- name: Clone kickstart.nvim
   ansible.builtin.git:
-    repo: https://github.com/morhetz/gruvbox.git
-    dest: "{{ ['~' + macbook_user.stdout, '.local', 'share', 'nvim', 'site', 'pack', 'colors', 'start', 'gruvbox'] | path_join }}"
-    version: master
-    depth: 1
+    repo: https://github.com/nvim-lua/kickstart.nvim.git
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'nvim'] | path_join }}"
+    clone: true
+    update: false
 
 - name: Copy darwin-specific zsh files
   ansible.builtin.copy:

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -139,6 +139,8 @@
     - "surge"
     - "agent-browser"
     - "linearctl"
+    - "tree-sitter-cli"
+    - "typescript-language-server"
 
 - name: pip installs
   pip:


### PR DESCRIPTION
switch to kickstart.nvim and add desktop app bindings
- Replace custom neovim init.lua + gruvbox with kickstart.nvim clone
- Add app-to-desktop binding system via space UUIDs and defaults
- Move Karabiner and KM16 tasks from claude role to desktop role
- Move second brain directories from claude role to functions/darwin
- Add Shift+Enter key binding to WezTerm for terminal escape sequence
- Install tree-sitter-cli and typescript-language-server via Homebrew
- Remove generated timestamp from KM16 infographic footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added application-to-desktop binding configuration for macOS Spaces.
  * Added new Shift+Enter key binding in terminal.
  * Added second-brain vault directory structure with subdirectories.

* **Chores**
  * Updated KM16 Pro reference footer text.
  * Added `tree-sitter-cli` and `typescript-language-server` to global npm packages.
  * Automated Karabiner configuration setup.
  * Updated Neovim setup to use kickstart.nvim configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->