### PR TITLE
gh dash

### DIFF
--- a/files/gh-dash/config.yml
+++ b/files/gh-dash/config.yml
@@ -1,0 +1,92 @@
+prSections:
+    - title: My Pull Requests
+      filters: is:open author:@me
+    - title: Needs My Review
+      filters: is:open review-requested:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+issuesSections:
+    - title: My Issues
+      filters: is:open author:@me
+    - title: Assigned
+      filters: is:open assignee:@me
+    - title: Involved
+      filters: is:open involves:@me -author:@me
+notificationsSections:
+    - title: All
+      filters: ""
+    - title: Created
+      filters: reason:author
+    - title: Participating
+      filters: reason:participating
+    - title: Mentioned
+      filters: reason:mention
+    - title: Review Requested
+      filters: reason:review-requested
+    - title: Assigned
+      filters: reason:assign
+    - title: Subscribed
+      filters: reason:subscribed
+    - title: Team Mentioned
+      filters: reason:team-mention
+repo:
+    branchesRefetchIntervalSeconds: 30
+    prsRefetchIntervalSeconds: 60
+defaults:
+    preview:
+        open: true
+        width: 0.45
+    prsLimit: 20
+    prApproveComment: LGTM
+    issuesLimit: 20
+    notificationsLimit: 20
+    view: prs
+    layout:
+        prs:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 20
+            author:
+                width: 15
+            authorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+            base:
+                width: 15
+                hidden: true
+            lines:
+                width: 15
+        issues:
+            updatedAt:
+                width: 5
+            createdAt:
+                width: 5
+            repo:
+                width: 15
+            creator:
+                width: 10
+            creatorIcon:
+                hidden: false
+            assignees:
+                width: 20
+                hidden: true
+    refetchIntervalMinutes: 30
+keybindings: {}
+repoPaths: {}
+theme:
+    ui:
+        sectionsShowCount: true
+        table:
+            showSeparator: true
+            compact: false
+pager:
+    diff: delta --side-by-side --paging=always
+confirmQuit: false
+showAuthorIcons: true
+smartFilteringAtLaunch: true
+includeReadNotifications: true

--- a/files/karabiner/karabiner.json
+++ b/files/karabiner/karabiner.json
@@ -360,11 +360,27 @@
             ]
           },
           {
-            "description": "KM16 L0: 7 — Cycle app windows (⌘`)",
+            "description": "KM16 L0: 7 — Cycle WezTerm tab",
             "manipulators": [
               {
                 "type": "basic",
                 "from": { "key_code": "7", "modifiers": { "optional": ["any"] } },
+                "to": [
+                  { "shell_command": "/Applications/WezTerm.app/Contents/MacOS/wezterm cli activate-tab --tab-relative 1" }
+                ],
+                "conditions": [
+                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
+                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "KM16 L0: 8 — Cycle app windows (⌘`)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": { "key_code": "8", "modifiers": { "optional": ["any"] } },
                 "to": [
                   { "key_code": "grave_accent_and_tilde", "modifiers": ["command"] }
                 ],
@@ -376,29 +392,13 @@
             ]
           },
           {
-            "description": "KM16 L0: 8 — New WezTerm window",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": { "key_code": "8", "modifiers": { "optional": ["any"] } },
-                "to": [
-                  { "shell_command": "/usr/local/bin/macropad_action wezterm" }
-                ],
-                "conditions": [
-                  { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },
-                  { "type": "variable_if", "name": "km16_layer", "value": 0 }
-                ]
-              }
-            ]
-          },
-          {
-            "description": "KM16 L0: 9 — Jump to Desktop 9",
+            "description": "KM16 L0: 9 — New WezTerm window",
             "manipulators": [
               {
                 "type": "basic",
                 "from": { "key_code": "9", "modifiers": { "optional": ["any"] } },
                 "to": [
-                  { "shell_command": "osascript -e 'tell application \"System Events\" to key code 25 using {control down}'" }
+                  { "shell_command": "/usr/local/bin/macropad_action wezterm" }
                 ],
                 "conditions": [
                   { "type": "device_if", "identifiers": [{ "vendor_id": 10473, "product_id": 12613 }, { "vendor_id": 10473, "product_id": 8192 }, { "vendor_id": 1389, "product_id": 49271 }] },

--- a/files/km16/index.html
+++ b/files/km16/index.html
@@ -92,21 +92,21 @@
             <span class="text-xs text-cream/50">7</span>
             <div>
               <p class="text-sm font-bold">Cycle</p>
-              <p class="text-xs text-cream/60">windows</p>
+              <p class="text-xs text-cream/60">tab</p>
             </div>
           </div>
           <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
             <span class="text-xs text-cream/50">8</span>
             <div>
-              <p class="text-sm font-bold">WezTerm</p>
-              <p class="text-xs text-cream/60">new window</p>
+              <p class="text-sm font-bold">Cycle</p>
+              <p class="text-xs text-cream/60">windows</p>
             </div>
           </div>
           <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">
             <span class="text-xs text-cream/50">9</span>
             <div>
-              <p class="text-sm font-bold">Desktop</p>
-              <p class="text-xs text-cream/60">9</p>
+              <p class="text-sm font-bold">WezTerm</p>
+              <p class="text-xs text-cream/60">new window</p>
             </div>
           </div>
           <div class="bg-black text-cream border-4 border-black p-4 aspect-square flex flex-col justify-between">

--- a/files/wezterm.lua
+++ b/files/wezterm.lua
@@ -158,6 +158,7 @@ config.color_schemes = {
     brights = { '#482430', '#ff86b0', '#d0ffbe', '#ffffd7', '#d09bca', '#ff86b0', '#8fbcbb', '#ffffff' },
   },
 }
+local opaque_themes = { asda = true, liege = true }
 config.color_scheme = 'coffee'
 config.window_background_opacity = 0.80
 config.macos_window_background_blur = 20
@@ -166,6 +167,7 @@ config.window_decorations = 'TITLE | RESIZE'
 config.window_padding = { left = 4, right = 4, top = 4, bottom = 4 }
 config.use_fancy_tab_bar = false
 config.hide_tab_bar_if_only_one_tab = true
+config.tab_max_width = 999
 config.colors = {
   split = '#ffffff',
   tab_bar = {
@@ -241,6 +243,7 @@ config.keys = {
 local function get_pane_info(pane)
   local process = pane.foreground_process_name or ''
   local proc = process:match('[^/]+$') or 'shell'
+  if proc:match('^claude') then proc = 'claude' end
   local cwd = ''
   local url = pane.current_working_dir
   if url then
@@ -264,12 +267,22 @@ end)
 wezterm.on('format-tab-title', function(tab)
   local proc, cwd = get_pane_info(tab.active_pane)
   local index = tab.tab_index + 1
-  return string.format(' %d %s %s ', index, proc, cwd)
+  return string.format('        %s        ', proc)
 end)
 
-wezterm.on('user-var-changed', function(window, _, name, _)
+wezterm.on('user-var-changed', function(window, pane, name, value)
   if name == 'focus' then
     window:focus()
+  elseif name == 'theme' then
+    local overrides = window:get_config_overrides() or {}
+    if opaque_themes[value] then
+      overrides.window_background_opacity = 1.0
+      overrides.macos_window_background_blur = 0
+    else
+      overrides.window_background_opacity = 0.80
+      overrides.macos_window_background_blur = 20
+    end
+    window:set_config_overrides(overrides)
   end
 end)
 

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -64,6 +64,11 @@ _wez_layout() {
   wezterm cli activate-pane --pane-id "$main_pane"
   local cmd=$(printf '%q ' "$@")
   printf '%s\n' "$cmd" | wezterm cli send-text --pane-id "$main_pane" --no-paste
+
+  local dash_pane
+  dash_pane=$(wezterm cli spawn --cwd "$PWD")
+  [[ -n "$dash_pane" ]] && printf 'gh dash\n' | wezterm cli send-text --pane-id "$dash_pane" --no-paste
+  wezterm cli activate-pane --pane-id "$main_pane"
 }
 
 _claude_wez() {

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -78,34 +78,41 @@ repos () { # List all repos # ➜ repos public
 }
 
 _issue_to_branch() {
-  local issue_url="$1"
-  local num=$(echo "$issue_url" | awk -F'/' '{print $NF}')
-  local title=$(gh issue view "$num" --json title -q '.title')
+  local input="$1"
+  local num
+  [[ "$input" =~ ^[0-9]+$ ]] && num="$input" || num=$(echo "$input" | awk -F'/' '{print $NF}')
+  local title
+  title=$(gh issue view "$num" --json title -q '.title') || return 1
   local slug=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd 'a-z0-9-' | sed 's/--*/-/g; s/^-//; s/-$//')
   git checkout -b "gh-${num}-${slug}"
 }
 
-issue() { # Create gh issue and branch, or edit existing # ➜ issue | issue "fix nginx" | issue 505
-  [[ -f .linear ]] && echo "This project uses Linear — use Linear to create branches" && return 1
+issue() { # Create gh issue or edit existing # ➜ issue | issue "fix nginx" | issue 505
+  [[ -f .linear ]] && echo "This project uses Linear — use Linear to create issues" && return 1
   local default=$(_default_branch)
   local current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-
-  [[ ! "$1" =~ ^[0-9]+$ && "$current" != "$default" ]] && {
-    echo "Switch to $default before creating an issue"
-    return 1
-  }
 
   if [[ -z "$1" ]]; then
     local url
     url=$(gh issue create -e) || return 1
-    [[ -n "$url" ]] && _issue_to_branch "$url"
+    [[ -z "$url" ]] && return 1
+    if [[ "$current" == "$default" ]]; then
+      _issue_to_branch "$url"
+    else
+      echo "$url"
+    fi
     return
   fi
 
   [[ ! "$1" =~ ^[0-9]+$ ]] && {
     local url
-    url=$(gh issue create -t "$1" ${2:+-b "$2"}) || return 1
-    [[ -n "$url" ]] && _issue_to_branch "$url"
+    url=$(gh issue create -t "$1" -b "${2:-}") || return 1
+    [[ -z "$url" ]] && return 1
+    if [[ "$current" == "$default" ]]; then
+      _issue_to_branch "$url"
+    else
+      echo "$url"
+    fi
     return
   }
 
@@ -459,9 +466,11 @@ _colorize_commit_type () {
 
 _format_pr_body () {
   local default=$(_default_branch)
+  local branch=$(git branch --show-current)
   local commits=$(git log $default.. --pretty=%B | sed 's/^[a-zA-Z0-9_]*: //' | sed '/^$/d')
-  # local body="## Why\n\n\n\n## What changed\n\n${commits}\n\n## How to test\n\n"
-  echo "$commits"
+  local body="$commits"
+  [[ "$branch" =~ ^gh-([0-9]+) ]] && body="${body}\n\nCloses #${match[1]}"
+  echo "$body"
 }
 
 ghpr () { # Create and validate a PR
@@ -481,23 +490,16 @@ ghpr () { # Create and validate a PR
   fi
 }
 
-gbr () { # Create branch with GH issue or local counter # ➜ gbr fix-nginx-config
-  [[ ! $1 ]] && echo "Usage: gbr <slug>" && return 1
-  [[ -f .linear ]] && echo "This project uses Linear — use Linear to create branches" && return 1
+gbr () { # Create branch from GH issue or literal name # ➜ gbr 42 | gbr user/lin-123-slug
+  [[ ! $1 ]] && echo "Usage: gbr <issue-number> or gbr <branch-name>" && return 1
   local default=$(_default_branch)
   local current=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
   [[ "$current" != "$default" ]] && echo "Switch to $default before creating a branch" && return 1
-  local slug="$1"
-  local title=$(echo "$slug" | tr '-' ' ')
-  if gh repo view --json nameWithOwner -q .nameWithOwner &>/dev/null; then
-    local issue_url
-    issue_url=$(gh issue create -t "$title" -b "") || return 1
-    local num=$(echo "$issue_url" | awk -F'/' '{print $NF}')
-    git checkout -b "gh-${num}-${slug}"
+
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    _issue_to_branch "$1"
   else
-    local max=$(git branch -a --list 'cl-*' | sed -E 's/.*cl-([0-9]+).*/\1/' | sort -rn | head -1)
-    local next=$(( ${max:-0} + 1 ))
-    git checkout -b "cl-${next}-${slug}"
+    git checkout -b "$1"
   fi
 }
 

--- a/files/zsh/nav.zsh
+++ b/files/zsh/nav.zsh
@@ -144,6 +144,7 @@ _wez_apply_theme() {
   done
 
   export __WEZTERM_THEME="$name"
+  printf '\033]1337;SetUserVar=%s=%s\a' theme "$(echo -n "$name" | base64)"
 }
 
 cpr() { # Set terminal color theme # ➜ cpr coffee

--- a/makefiles/roles.mk
+++ b/makefiles/roles.mk
@@ -1,7 +1,7 @@
 # Ansible tag targets - auto-generated from ANSIBLE_TAGS list
 # To add a new target, just add the tag name to ANSIBLE_TAGS
 
-ANSIBLE_TAGS := terminal install debian nginx rails vscode functions claude keepalive diskspace desktop ruben agent ssh cyrus
+ANSIBLE_TAGS := terminal install debian nginx rails vscode functions claude keepalive diskspace desktop ruben agent ssh cyrus karabiner
 
 define ansible_tag
 .PHONY: $(1)

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -45,17 +45,20 @@
   file:
     path: "{{ [ansible_env.HOME, '.config', 'karabiner'] | path_join }}"
     state: directory
+  tags: karabiner
 
 - name: Copy Karabiner config
   copy:
     src: karabiner/karabiner.json
     dest: "{{ [ansible_env.HOME, '.config', 'karabiner', 'karabiner.json'] | path_join }}"
     force: yes
+  tags: karabiner
 
 - name: Generate KM16 infographic
   ansible.builtin.command:
     cmd: python3 files/km16/generate.py
     chdir: "{{ playbook_dir }}"
+  tags: karabiner
 
 - name: Remove superfluous from dock
   shell: /usr/local/bin/dockutil --remove '{{ item }}' | cat

--- a/roles/functions/tasks/darwin.yml
+++ b/roles/functions/tasks/darwin.yml
@@ -61,17 +61,22 @@
     - starting
   when: inventory_hostname != 'github-runner.localhost'
 
-- name: Copy WezTerm config
-  ansible.builtin.copy:
-    src: wezterm.lua
-    dest: "{{ ['~' + macbook_user.stdout, '.wezterm.lua'] | path_join }}"
-
 - name: Clone kickstart.nvim
   ansible.builtin.git:
     repo: https://github.com/nvim-lua/kickstart.nvim.git
     dest: "{{ ['~' + macbook_user.stdout, '.config', 'nvim'] | path_join }}"
     clone: true
     update: false
+
+- name: Create gh-dash config directory
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, '.config', 'gh-dash'] | path_join }}"
+    state: directory
+
+- name: Copy gh-dash config
+  ansible.builtin.copy:
+    src: gh-dash/config.yml
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'gh-dash', 'config.yml'] | path_join }}"
 
 - name: Copy darwin-specific zsh files
   ansible.builtin.copy:

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -55,6 +55,7 @@
       - "neonctl"
       - "uv"
       - "semgrep"
+      - "git-delta"
       - "shellcheck"
       - "librsvg"
       - "marcus/tap/nightshift"
@@ -159,6 +160,14 @@
 - name: Install Claude Code
   shell: curl -fsSL https://claude.ai/install.sh | bash
   when: not claude_installed.stat.exists
+
+- name: Install gh extensions
+  shell: gh extension install {{ item }}
+  loop:
+    - "dlvhdr/gh-dash"
+  register: gh_ext_result
+  changed_when: "'already installed' not in gh_ext_result.stderr"
+  failed_when: gh_ext_result.rc != 0 and 'already installed' not in gh_ext_result.stderr
 
 - name: link node
   shell: "{{ brew_location.stdout }} link --overwrite node@{{ node_version }}"

--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -1,4 +1,9 @@
 ---
+- name: Copy WezTerm config
+  ansible.builtin.copy:
+    src: wezterm.lua
+    dest: "{{ ['~' + macbook_user.stdout, '.wezterm.lua'] | path_join }}"
+
 - name: Cloning oh-my-zsh
   git:
     repo: https://github.com/ohmyzsh/ohmyzsh


### PR DESCRIPTION
add gh-dash and rework git branch helpers
- Install gh-dash extension and git-delta via Ansible
- Provision gh-dash config to ~/.config/gh-dash/
- Rework gbr to accept issue numbers or literal branch names
- Allow issue creation from non-default branches without auto-checkout
- Auto-append "Closes #N" to PR bodies for gh-* branches
- Accept bare issue numbers in _issue_to_branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in GitHub Dashboard with configurable sections, notifications, preview, and limits.
* **Improvements**
  * Streamlined issue/branch commands and clearer issue-creation behavior (URLs echoed when appropriate).
  * WezTerm: wider tabs, simplified centered titles, theme-aware opacity/blur handling, and automatic secondary pane dashboard spawn in some flows.
  * Macropad/Karabiner: updated key labels/actions for window/tab controls.
* **Chores**
  * Installer adds git-delta and GitHub dashboard extension; deployment tasks and tags updated for Karabiner and configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->