### PR TITLE
gh-557: review in code

### DIFF
--- a/files/claude/skills/cr/SKILL.md
+++ b/files/claude/skills/cr/SKILL.md
@@ -40,16 +40,23 @@ gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
   | jq '[.[] | select(.user.login == "coderabbitai[bot]") | {id, state, body}]'
 ```
 
-### 3. Present findings
+### 3. Grade and present findings
 
-Display each comment in a numbered list:
+For each comment, read the actual code and CLAUDE.md conventions, then assign your own grade A-F with a score out of 100. Do NOT parrot CodeRabbit's severity markers — apply independent judgement.
+
+**Grading scale:**
+- **A (90-100)** — Real bug, security issue, or will break at runtime. Fix this.
+- **B (75-89)** — Legitimate improvement, meaningful code quality gain.
+- **C (50-74)** — Valid point but low impact. Fix if convenient.
+- **D (25-49)** — Overly cautious or stylistic preference that doesn't match project conventions.
+- **F (0-24)** — Pedantic, wrong, or conflicts with project patterns. Ignore.
+
+Display each comment in a numbered list with grade and score:
 
 ```
-1. [Minor] files/nvim/init.lua:252 — stylua is a formatter, not an LSP server
-2. [Minor] files/nvim/init.lua:348 — cmp.entry.get_documentation targets wrong plugin
+1. B 78 files/zsh/git.zsh:8 — run_id can be literal "null", guard needed
+2. F 15 files/gh-dash/config.yml:81 — suggests removing Octo config (unrelated cleanup)
 ```
-
-Severity comes from the comment body markers: `⚠️ Potential issue`, `🧹 Nitpick`, `🔴 Major`, `🟡 Minor`.
 
 If no CodeRabbit comments found, say so and stop.
 

--- a/files/gh-dash/config.yml
+++ b/files/gh-dash/config.yml
@@ -79,12 +79,15 @@ defaults:
 keybindings:
     prs:
         - key: o
-          command: nvim -c ":Octo pr edit {{.PrNumber}}"
-          name: Open in Octo
+          command: code --open-url "vscode://github.vscode-pull-request-github/open-pull-request-changes?uri=https://github.com/{{.RepoName}}/pull/{{.PrNumber}}"
+          name: Open in VS Code
+        - key: O
+          command: gh pr view {{.PrNumber}} --repo {{.RepoName}} --web
+          name: Open in browser
     issues:
         - key: o
-          command: nvim -c ":Octo issue edit {{.IssueNumber}}"
-          name: Open in Octo
+          command: gh issue view {{.IssueNumber}} --repo {{.RepoName}} --web
+          name: Open in browser
 repoPaths: {}
 theme:
     ui:

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -1,4 +1,16 @@
 unalias gbr 2>/dev/null
+unalias gpf 2>/dev/null
+
+_watch_ci() {
+  sleep 3
+  local run_id
+  run_id=$(gh run list --branch "$(git branch --show-current)" --limit 1 --json databaseId --jq '.[0].databaseId')
+  [[ -n "$run_id" ]] && gh run watch "$run_id"
+}
+
+gpf() { # Force push and watch CI # ➜ gpf
+  git push --force-with-lease --force-if-includes && _watch_ci
+}
 
 changes() { # View diff in diffnav # ➜ changes | changes main
   git diff ${1:+$1...} | diffnav
@@ -491,7 +503,7 @@ ghpr () { # Create and validate a PR
     gh pr edit $pr --body "$(_format_pr_body)"
   else
     gh pr create --title "$modified_title" --body "$(_format_pr_body)"
-  fi
+  fi && _watch_ci
 }
 
 gbr () { # Create branch from GH issue or literal name # ➜ gbr 42 | gbr user/lin-123-slug


### PR DESCRIPTION
open gh-dash PRs in VS Code instead of Octo
- Replace Octo keybinding with VS Code PR extension URI handler
- Add shift-O to open PR in browser
- Switch issue open to browser view

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VS Code deep-linking to open and review pull request changes
  * New CLI helpers: force-push shortcut and automatic CI run watcher after push/PR actions

* **Changes**
  * Added browser shortcuts to open pull requests and issues
  * Updated keyboard shortcuts and labels for PR/issue workflows

* **Documentation**
  * Updated guidance for grading and presenting findings with an A–F rubric and numeric scores
<!-- end of auto-generated comment: release notes by coderabbit.ai -->