### PR TITLE
gh-569: last gh run

### DIFF
--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -240,6 +240,15 @@ runs () { # List workflow runs # ➜ runs
   [[ $1 ]] && gh run view $1 || gh run list
 }
 
+ci() { # View latest CI run logs for current branch # ➜ ci
+  local branch run_id job_id
+  branch=$(git branch --show-current)
+  run_id=$(gh run list --branch "$branch" --limit 1 --json databaseId --jq '.[0].databaseId')
+  [[ -z "$run_id" ]] && echo "No runs for $branch" && return 1
+  job_id=$(gh run view "$run_id" --json jobs --jq '[.jobs[] | select(.conclusion == "failure")][0].databaseId // .jobs[-1].databaseId')
+  gh run view --job "$job_id" --log-failed 2>/dev/null || gh run view --job "$job_id" --log
+}
+
 branches () {
   echo $(git branch | wc -l) branches
   git branch


### PR DESCRIPTION
add ci function for viewing latest branch CI run

Closes #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quickly view the latest CI workflow run for your current Git branch without specifying branch names.
  * Automatically opens the most relevant job logs (preferring failed-job logs, falling back to full logs) and prints a clear message if no runs are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->