### PR TITLE
gh-572: add global pre commit hook to warn when branch is already merged

### DIFF
--- a/files/claude/skills/recap/skill.md
+++ b/files/claude/skills/recap/skill.md
@@ -1,0 +1,48 @@
+---
+name: recap
+description: Summarise what happened in this session so far. Use when switching between Claude sessions or returning after a break.
+user_invocable: true
+---
+
+# Recap
+
+Summarise the current session for quick re-orientation.
+
+## Steps
+
+1. Review the conversation history in this session. Identify:
+   - What was worked on
+   - Key decisions made and why
+   - What changed (files edited, commits made)
+   - Current state (done, in progress, blocked)
+   - What's next
+
+2. Print a concise recap:
+
+```
+## Recap
+
+**Branch**: [current branch]
+**Working on**: [1 sentence]
+
+### Done
+- [completed items]
+
+### Decisions
+- [key decisions with reasoning]
+
+### Current state
+[where things stand right now]
+
+### Next
+- [what to do next]
+```
+
+## Rules
+
+- Only report what actually happened in this session, never fabricate
+- Keep it scannable. One line per item, no paragraphs
+- Skip sections that have nothing to report
+- If commits were made, mention them by message
+- If a plan exists, mention its status (draft, approved, in progress, done)
+- Run `git status` and `git log --oneline -3` to ground the recap in actual state

--- a/files/git/check_merged_branch
+++ b/files/git/check_merged_branch
@@ -1,0 +1,20 @@
+#!/bin/bash
+branch="$(git branch --show-current)"
+[ -z "$branch" ] && exit 0
+
+default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+default_branch="${default_branch:-main}"
+[ "$branch" = "$default_branch" ] && exit 0
+git rev-parse --verify "origin/$default_branch" >/dev/null 2>&1 || exit 0
+[ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$default_branch")" ] && exit 0
+
+merged=false
+# Regular merge: HEAD is ancestor of default branch
+git merge-base --is-ancestor HEAD "origin/$default_branch" 2>/dev/null && merged=true
+# Squash merge: tree content identical to default branch
+[ "$merged" = false ] && git diff --quiet "origin/$default_branch" "$branch" 2>/dev/null && merged=true
+
+if [ "$merged" = true ]; then
+  echo "This branch is already merged into $default_branch. Switch to a new branch first."
+  exit 1
+fi

--- a/files/git/pre-commit
+++ b/files/git/pre-commit
@@ -1,9 +1,15 @@
+#!/bin/bash
 branch="$(git branch --show-current)"
 commits="$(git rev-list --all)"
 
 if [ "$branch" = "main" ] && [ "$commits" != "" ]; then
   echo "Commit on main branch is blocked, there are already existing commits."
   exit 1
+fi
+
+hooks_dir="$(dirname "$0")"
+if [ -f "$hooks_dir/check_merged_branch" ]; then
+  "$hooks_dir/check_merged_branch" || exit $?
 fi
 
 if [ -f package-lock.json ] && [ -f yarn.lock ]; then

--- a/files/git/pre-push
+++ b/files/git/pre-push
@@ -9,6 +9,11 @@ while read -r _ _ remote_ref _; do
   exit 1
 done
 
+hooks_dir="$(dirname "$0")"
+if [ -f "$hooks_dir/check_merged_branch" ]; then
+  "$hooks_dir/check_merged_branch" || exit $?
+fi
+
 # Run verify target if available
 if [[ -f Makefile ]] && grep -q '^verify:' Makefile; then
   echo "Running make verify..."

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -1,6 +1,8 @@
 unalias gbr 2>/dev/null
 unalias gpf 2>/dev/null
 
+_is_git_repo() { git rev-parse --is-inside-work-tree &>/dev/null; }
+
 _watch_ci() {
   local branch run_id
   branch=$(git branch --show-current)
@@ -21,7 +23,7 @@ changes() { # View diff in diffnav # ➜ changes | changes main
 }
 
 gitundo () { # Undo last git operation (safe: fails if uncommitted changes conflict)
-  [[ ! -d .git ]] && echo "Not a git repo" && return 1
+  _is_git_repo || { echo "Not a git repo"; return 1; }
   local current=$(git rev-parse --short HEAD)
   local target=$(git rev-parse --short HEAD@{1} 2>/dev/null)
   [[ -z "$target" ]] && echo "Nothing to undo" && return 1
@@ -32,13 +34,13 @@ gitundo () { # Undo last git operation (safe: fails if uncommitted changes confl
 }
 
 gitops () { # Show recent git operations # ➜ gitops 20
-  [[ ! -d .git ]] && echo "Not a git repo" && return 1
+  _is_git_repo || { echo "Not a git repo"; return 1; }
   local count=${1:-10}
   git reflog -n "$count" --format='%C(yellow)%h %C(green)%gd %C(reset)%gs %C(dim)%ar%C(reset)'
 }
 
 gitrestore () { # Restore to a reflog entry (safe) # ➜ gitrestore 3
-  [[ ! -d .git ]] && echo "Not a git repo" && return 1
+  _is_git_repo || { echo "Not a git repo"; return 1; }
   [[ -z "$1" ]] && gitops && return
   local target="HEAD@{$1}"
   local hash=$(git rev-parse --short "$target" 2>/dev/null)
@@ -55,7 +57,7 @@ gitrestore () { # Restore to a reflog entry (safe) # ➜ gitrestore 3
 GIT_FETCH_THROTTLE_SECONDS=${GIT_FETCH_THROTTLE_SECONDS:-300}
 
 _git_sync() {
-  [[ ! -d .git ]] && return
+  _is_git_repo || return
   local current_branch=$(git rev-parse --abbrev-ref HEAD)
   local default=$(_default_branch)
 
@@ -167,7 +169,7 @@ secrets () {
 }
 
 workflows () { # Copy template workflow to repo # ➜ workflows test
-  [[ ! -d .git ]] && git rev-parse --git-dir > /dev/null 2>&1 && cd $(git rev-parse --show-toplevel)
+  _is_git_repo && [[ ! -d .git ]] && cd $(git rev-parse --show-toplevel)
   local _dir=~/.templates/github-actions
   local app_name=$(basename $(pwd))
 
@@ -200,7 +202,7 @@ issues () { # List gh issues
 
  _releases_across_repos () {
   for i in */; do
-    if [ -d "$i".git ]; then
+    if [ -e "$i".git ]; then
        (
         cd "$i"
         local repo_name=$(basename $(git rev-parse --show-toplevel))
@@ -212,7 +214,7 @@ issues () { # List gh issues
  }
 
 releases () { # List releases for repo # ➜ releases 5
-  if [ ! -d .git ]; then
+  if ! _is_git_repo; then
     _releases_across_repos
     return
   fi
@@ -221,7 +223,7 @@ releases () { # List releases for repo # ➜ releases 5
 }
 
 prs () { # List open prs
-  if [ ! -d .git ]; then
+  if ! _is_git_repo; then
     _allprs
     return
   fi
@@ -230,7 +232,7 @@ prs () { # List open prs
 
 _allprs () {
   for i in */; do
-    if [ -d "$i".git ]; then
+    if [ -e "$i".git ]; then
       (cd "$i" && prs)
     fi
   done
@@ -246,7 +248,7 @@ branches () {
 }
 
 commits () { # List recent commits # ➜ commits 5
-  if [ ! -d .git ]; then
+  if ! _is_git_repo; then
     _commits_across_repos
     return
   fi
@@ -268,7 +270,7 @@ commits () { # List recent commits # ➜ commits 5
 _commits_across_repos () {
   [[ $1 ]] && no=$1 || no=2
   for i in */; do
-    if [ -d "$i".git ]; then
+    if [ -e "$i".git ]; then
      (
         cd "$i"
         repo_name=$(basename $(git rev-parse --show-toplevel))
@@ -366,7 +368,7 @@ _default_branch () {
 }
 
 unmerged () { # List unmerged commits # ➜ unmerged 5
-  if [ ! -d .git ]; then
+  if ! _is_git_repo; then
     _unmerged_commits_across_repos
     return
   fi
@@ -384,7 +386,7 @@ unmerged () { # List unmerged commits # ➜ unmerged 5
 
 _unmerged_commits_across_repos () {
   for i in */; do
-    if [ -d "$i".git ]; then
+    if [ -e "$i".git ]; then
       (
         cd "$i"
         local output=$(unmerged 2)
@@ -398,7 +400,7 @@ _unmerged_commits_across_repos () {
       )
     fi
   done
-  [ -d .git ] && unmerged 5
+  _is_git_repo && unmerged 5
 }
 
 

--- a/roles/functions/tasks/git.yml
+++ b/roles/functions/tasks/git.yml
@@ -18,6 +18,12 @@
     path: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks'] | path_join }}"
     state: directory
 
+- name: Copy merged branch check script
+  copy:
+    src: git/check_merged_branch
+    dest: "{{ ['~' + macbook_user.stdout, '.config', 'git', 'hooks', 'check_merged_branch'] | path_join }}"
+    mode: a+x
+
 - name: Copy global pre-commit hook
   copy:
     src: git/pre-commit


### PR DESCRIPTION
block commits on branches already merged into main
- Add merged-branch check to global pre-commit hook
- Add shebang to pre-commit hook
- Add recap skill to Claude

Closes #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-invocable "recap" skill that produces a structured session summary (branch, one-line current work, Done, Decisions, Current state, Next).
  * Git hooks now block commit/push when the current branch appears already merged into the default branch.

* **Chores**
  * Improved shell git-awareness and command gating for repo detection.
  * Added an installer task to deploy the merge-check hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->