### PR TITLE
gh-577: promote trialling tools into macfair

### DIFF
--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -516,3 +516,22 @@ _drift_complete() {
   fi
 }
 compdef _drift_complete drift 2>/dev/null
+
+zj() {
+  local layout="${TMPDIR:-/tmp}/zj_layout_$$.kdl"
+  cat > "$layout" <<'KDL'
+layout {
+  pane split_direction="vertical" {
+    pane size="70%" command="claude" {
+      args "--permission-mode" "plan"
+    }
+    pane split_direction="horizontal" size="30%" {
+      pane
+      pane
+    }
+  }
+}
+KDL
+  zellij -l "$layout" "$@"
+  rm -f "$layout"
+}

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -664,6 +664,18 @@ wt() { # Create a git worktree # ➜ wt floating-panes | wt 42
   git worktree add "$worktree_path" -b "$name" "$base" && echo "$worktree_path"
 }
 
+dif() {
+  GIT_EXTERNAL_DIFF=difft git diff "$@"
+}
+
+difl() {
+  GIT_EXTERNAL_DIFF=difft git log -p --ext-diff "$@"
+}
+
+difs() {
+  GIT_EXTERNAL_DIFF=difft git show --ext-diff "$@"
+}
+
 wtr() { # Remove a git worktree # ➜ wtr floating-panes
   local name="$1"
   local repo

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -62,6 +62,11 @@
       - "librsvg"
       - "marcus/tap/nightshift"
       - "marcus/tap/td"
+      - "helix"
+      - "zellij"
+      - "eza"
+      - "difftastic"
+      - "anomalyco/tap/opencode"
       - "marcus/tap/sidecar"
 
 - name: install core packages (best effort, older macOS)
@@ -119,6 +124,7 @@
     - "hamed-elfayome/claude-usage/claude-usage-tracker"
     - "stats"
     - "wezterm"
+    - "zed"
 
 - name: Copy zshenv
   copy:


### PR DESCRIPTION
promote trialling tools into macfair
- Add helix, zellij, eza, difftastic, opencode to brew core packages
- Add zed to brew cask apps
- Add difftastic wrappers dif(), difl(), difs() to git.zsh
- Add zellij+claude layout function zj() to claude.zsh

Closes #577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `zj` command for launching Zellij with a pre-configured layout optimized for workflow
  * Added `dif`, `difl`, and `difs` commands for enhanced Git diff visualization

* **Chores**
  * Updated macOS Homebrew dependencies to include additional development tools (Helix, Zellij, Eza, Difftastic, Zed)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->