### PR TITLE
gh-589: deleteoldbranches fails to detect squash merged branches that were rebased before merge

### DIFF
--- a/files/cerico-w-user.zsh-theme
+++ b/files/cerico-w-user.zsh-theme
@@ -2,15 +2,18 @@ _update_pdir() {
   if [[ "$PWD" == "$HOME/worktrees/"* ]]; then
     local rel="${PWD#$HOME/worktrees/}"
     _pdir="${rel%%/*}:wt"
+    ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}[%{$fg[red]%}"
+    ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}] %{$fg[yellow]%}✗ "
+    ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}] "
   else
     _pdir="${PWD##*/}"
+    ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[red]%}"
+    ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗ "
+    ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "
   fi
 }
 add-zsh-hook precmd _update_pdir
 
 PROMPT='%{$fg_bold[cyan]%}☁ $USER@%m%{$reset_color%}:%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})${_pdir} ➜%{$reset_color%} $(git_prompt_info)'
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗ "
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "

--- a/files/cerico.zsh-theme
+++ b/files/cerico.zsh-theme
@@ -2,15 +2,18 @@ _update_pdir() {
   if [[ "$PWD" == "$HOME/worktrees/"* ]]; then
     local rel="${PWD#$HOME/worktrees/}"
     _pdir="${rel%%/*}:wt"
+    ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}[%{$fg[red]%}"
+    ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}] %{$fg[yellow]%}✗ "
+    ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}] "
   else
     _pdir="${PWD##*/}"
+    ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[red]%}"
+    ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗ "
+    ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "
   fi
 }
 add-zsh-hook precmd _update_pdir
 
 PROMPT='%{$fg_bold[cyan]%}☁ %m%{$reset_color%}:%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})${_pdir} ➜%{$reset_color%} $(git_prompt_info)'
 
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"
-ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗ "
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -292,12 +292,12 @@ releases () { # List releases for repo # ➜ releases 5
   git for-each-ref --sort=-creatordate --format '%(refname:short) %(creatordate:relative)' refs/tags | head -n $no | awk '{tag = $1; date = $2 " " $3 " " $4 " " $5 " " $6; printf "\033[0;32m%-7s \033[1;0m%-s\n", tag, date}'
 }
 
-prs () { # List open prs
+prs () { # List open prs, or open PR in VS Code # ➜ prs | prs 590
   if ! _is_git_repo; then
     _allprs
     return
   fi
-  [[ $1 ]] && gh pr view $1 || gh pr list
+  [[ $1 ]] && gh pr view $1 --web || gh pr list
 }
 
 _allprs () {
@@ -424,7 +424,7 @@ delete_old_branches () {
     local is_merged=false merge_type=""
     if [[ -z "$(git log $default..$branch)" ]]; then
       is_merged=true merge_type="merged"
-    elif [[ -z "$(git diff $default...$branch)" ]]; then
+    elif [[ -z "$(git cherry $default $branch | grep '^+')" ]]; then
       is_merged=true merge_type="squash-merged"
     fi
     [[ "$is_merged" != true ]] && continue


### PR DESCRIPTION
use git cherry for squash-merge detection in delete_old_branches
- Replace git diff three-dot check with git cherry which compares patch content, not commit SHAs
- Fixes rebased branches not being detected as squash-merged after merge base shifts

Closes #589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when identifying squash-merged branches during branch cleanup.

* **New Features**
  * PR command now opens a specific pull request in the web browser when given an argument.
  * Git prompt now dynamically adjusts its prefix and dirty/clean markers when inside worktree directories, providing clearer visual cues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->