### PR TITLE
gh-591: fix sandbox to mount worktrees broadly instead of per pwd

### DIFF
--- a/files/zsh/sandbox.zsh
+++ b/files/zsh/sandbox.zsh
@@ -10,20 +10,15 @@ _sandbox_exists() {
 }
 
 _sandbox_ensure() {
-  local workdir="$(pwd)"
+  [[ "$PWD" != "$HOME/worktrees/"* ]] && { echo "sandbox requires a worktree — use wt first"; return 1; }
   if ! _sandbox_exists; then
     echo "Creating sandbox VM (first time, takes a few minutes)..."
-    limactl create --name "$SANDBOX_VM" --mount "${workdir}:w" "$SANDBOX_TEMPLATE" || return 1
+    limactl create --name "$SANDBOX_VM" \
+      --mount "$HOME/worktrees:w" \
+      "$SANDBOX_TEMPLATE" || return 1
   fi
   if ! _sandbox_running; then
     echo "Starting sandbox VM..."
-    limactl start "$SANDBOX_VM" || return 1
-  fi
-  if ! limactl shell "$SANDBOX_VM" test -d "$workdir" 2>/dev/null; then
-    echo "Remounting sandbox for $workdir..."
-    limactl stop "$SANDBOX_VM" 2>/dev/null
-    limactl delete "$SANDBOX_VM" 2>/dev/null
-    limactl create --name "$SANDBOX_VM" --mount "${workdir}:w" "$SANDBOX_TEMPLATE" || return 1
     limactl start "$SANDBOX_VM" || return 1
   fi
 }


### PR DESCRIPTION
mount worktrees directory broadly instead of per-PWD in sandbox
- Guard sandbox to only run from ~/worktrees/ paths
- Mount ~/worktrees:w once instead of per-directory
- Remove remount logic that deleted and recreated VM on directory change
- Fix missing semicolon before closing brace in guard clause

Closes #591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sandbox directory mounting behavior to always mount the `$HOME/worktrees` directory instead of the current directory. Added a requirement that the current working directory must be under `$HOME/worktrees/` when using the sandbox. Removed unnecessary sandbox recreation logic for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->