### PR TITLE
gh-597: claude mounts in lima

### DIFF
--- a/files/claude/skills/greptile/SKILL.md
+++ b/files/claude/skills/greptile/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: greptile
+description: Fetch and address Greptile review comments on the current branch's PR.
+user-invocable: true
+argument: optional PR number (auto-detects from current branch if omitted)
+---
+
+# Greptile Review
+
+Fetch Greptile review comments from the current PR and address them with judgement.
+
+## Usage
+
+- `/greptile` - Fetch comments for current branch's PR
+- `/greptile 597` - Fetch comments for a specific PR
+
+## Steps
+
+### 1. Detect PR
+
+```bash
+# If no argument, detect from current branch
+gh pr list --head "$(git branch --show-current)" --json number,url -q '.[0]'
+```
+
+If no PR found, tell the user and stop.
+
+### 2. Fetch Greptile comments
+
+```bash
+REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner')"
+PR_NUMBER="${1:-$(gh pr list --head "$(git branch --show-current)" --json number -q '.[0].number')}"
+
+# Inline comments (most actionable)
+gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" --paginate \
+  | jq '[.[] | select(.user.login == "greptile-apps[bot]") | {id, path, line, body, html_url}]'
+
+# Review summary (fallback if no inline comments)
+gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+  | jq '[.[] | select(.user.login == "greptile-apps[bot]") | {id, state, body}]'
+```
+
+### 3. Grade and present findings
+
+For each comment, read the actual code and CLAUDE.md conventions, then assign your own grade A-F with a score out of 100. Do NOT parrot Greptile's severity markers (P1/P2/etc.) — apply independent judgement.
+
+**Grading scale:**
+- **A (90-100)** — Real bug, security issue, or will break at runtime. Fix this.
+- **B (75-89)** — Legitimate improvement, meaningful code quality gain.
+- **C (50-74)** — Valid point but low impact. Fix if convenient.
+- **D (25-49)** — Overly cautious or stylistic preference that doesn't match project conventions.
+- **F (0-24)** — Pedantic, wrong, or conflicts with project patterns. Ignore.
+
+Display each comment in a numbered list with grade and score:
+
+```
+1. B 78 files/zsh/sandbox.zsh:27 — ~/.claude mount only applied to new VMs
+2. F 15 files/zsh/sandbox.zsh:10 — sed pattern edge case already guarded
+```
+
+If no Greptile comments found, say so and stop.
+
+### 4. User decides
+
+Ask the user which comments to address. Accept:
+- `all` — address every comment
+- `1, 3` — specific numbers
+- `skip` — done, don't fix anything
+- Or freeform like "fix the first one, ignore the nitpick"
+
+### 5. Apply fixes with judgement
+
+For each selected comment:
+1. Read the file and surrounding code
+2. Evaluate whether Greptile's suggestion is correct and appropriate
+3. If valid: apply the fix
+4. If disagree: explain why and skip it (e.g., "Greptile suggests X but this is intentional because Y")
+5. Show what was changed
+
+Do NOT blindly apply suggestions. Use the project's CLAUDE.md conventions and your own judgement. Greptile can be wrong, overly pedantic, or suggest changes that conflict with project patterns.
+
+### 6. Summary
+
+After addressing comments, show a summary:
+```
+Fixed: 1, 2
+Skipped: 3 (nitpick, not worth the churn)
+```

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -297,7 +297,13 @@ prs () { # List open prs, or open PR in VS Code # ➜ prs | prs 590
     _allprs
     return
   fi
-  [[ $1 ]] && gh pr view $1 --web || gh pr list
+  if [[ $1 ]]; then
+    local repo
+    repo=$(gh repo view --json nameWithOwner -q .nameWithOwner) || return 1
+    open "vscode://GitHub.vscode-pull-request-github/open-pull-request-changes?uri=https://github.com/$repo/pull/$1"
+  else
+    gh pr list
+  fi
 }
 
 _allprs () {
@@ -745,7 +751,9 @@ wt() { # Create a git worktree # ➜ wt floating-panes | wt 42
   git worktree add "$worktree_path" -b "$name" "$base" || return 1
   local main_root
   main_root="$(_repo_root)"
-  [[ -f "$main_root/.env" ]] && ln -sf "$main_root/.env" "$worktree_path/.env"
+  for item in .env .env.local .claude; do
+    [[ -e "$main_root/$item" && ! -e "$worktree_path/$item" ]] && ln -sf "$main_root/$item" "$worktree_path/$item"
+  done
 
   if [[ "$current" == "$base" ]]; then
     local pane_count=$(wezterm cli list --format json 2>/dev/null | jq "[.[] | select(.tab_id == ((.[] | select(.pane_id == $WEZTERM_PANE)) .tab_id))] | length" 2>/dev/null)

--- a/files/zsh/sandbox.zsh
+++ b/files/zsh/sandbox.zsh
@@ -2,19 +2,33 @@ SANDBOX_VM="claude-sandbox"
 SANDBOX_TEMPLATE="$HOME/macfair/files/lima/claude.yaml"
 
 _sandbox_running() {
-  limactl list --json 2>/dev/null | jq -e --arg name "$SANDBOX_VM" '.[] | select(.name == $name and .status == "Running")' &>/dev/null
+  limactl list --json 2>/dev/null | jq -e --arg name "$SANDBOX_VM" 'select(.name == $name and .status == "Running")' &>/dev/null
 }
 
 _sandbox_exists() {
-  limactl list --json 2>/dev/null | jq -e --arg name "$SANDBOX_VM" '.[] | select(.name == $name)' &>/dev/null
+  limactl list --json 2>/dev/null | jq -e --arg name "$SANDBOX_VM" 'select(.name == $name)' &>/dev/null
+}
+
+_sandbox_copy_gitignored() {
+  local main_root
+  main_root=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||')
+  [[ -z "$main_root" || "$main_root" == "$PWD" ]] && return
+
+  for item in .env .env.local .claude; do
+    [[ -e "$PWD/$item" && ! -L "$PWD/$item" ]] && continue
+    [[ -L "$PWD/$item" ]] && rm -f "$PWD/$item"
+    [[ -e "$main_root/$item" ]] && cp -a "$main_root/$item" "$PWD/$item" && echo "Copied $item from main repo"
+  done
 }
 
 _sandbox_ensure() {
   [[ "$PWD" != "$HOME/worktrees/"* ]] && { echo "sandbox requires a worktree — use wt first"; return 1; }
+  _sandbox_copy_gitignored
   if ! _sandbox_exists; then
     echo "Creating sandbox VM (first time, takes a few minutes)..."
     limactl create --name "$SANDBOX_VM" \
       --mount "$HOME/worktrees:w" \
+      --mount "$HOME/.claude:r" \
       "$SANDBOX_TEMPLATE" || return 1
   fi
   if ! _sandbox_running; then


### PR DESCRIPTION
mount Claude config and env files in sandbox VM
- Symlink .env.local and .claude alongside .env when creating worktrees
- Fix Lima NDJSON jq filters in sandbox helpers (remove .[] array syntax)
- Copy gitignored files into worktree before sandbox launch (symlinks don't cross VM boundary)
- Mount ~/.claude read-only into sandbox VM

Closes #597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open PRs directly in VS Code via deep-link when a PR number is provided.
  * New "greptile" review command that fetches Greptile comments, grades them, and lets you interactively apply selected fixes.
  * Worktree env handling: conditional sync for multiple env files (.env, .env.local, .claude).
  * Sandbox setup: automatic env-file sync and read-only mounting of user config into VMs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->