### PR TITLE
gh-601: ticket check zsh prompt

### DIFF
--- a/files/bin/speak
+++ b/files/bin/speak
@@ -5,9 +5,9 @@
 speak_out="/tmp/speak_out_$(tty 2>/dev/null | tr '/' '_').mp3"
 
 _speak() {
-  [[ -d /tmp/speak.lock ]] && (( $(date +%s) - $(stat -f%m /tmp/speak.lock) > 120 )) && rmdir /tmp/speak.lock 2>/dev/null
-  while ! mkdir /tmp/speak.lock 2>/dev/null; do sleep 0.2; done
-  trap 'rmdir /tmp/speak.lock 2>/dev/null; trap - INT TERM' INT TERM
+  [[ -d /tmp/speak_${USER}.lock ]] && (( $(date +%s) - $(stat -f%m /tmp/speak_${USER}.lock) > 120 )) && rmdir /tmp/speak_${USER}.lock 2>/dev/null
+  while ! mkdir /tmp/speak_${USER}.lock 2>/dev/null; do sleep 0.2; done
+  trap 'rmdir /tmp/speak_${USER}.lock 2>/dev/null; trap - INT TERM' INT TERM
 
   jq -n --arg text "$1" \
     '{model:"kokoro", input:$text, voice:"af_sky", response_format:"mp3"}' | \
@@ -16,7 +16,7 @@ _speak() {
       -d @- \
       -o "$speak_out" && afplay "$speak_out"
 
-  rmdir /tmp/speak.lock 2>/dev/null
+  rmdir /tmp/speak_${USER}.lock 2>/dev/null
   trap - INT TERM
 }
 

--- a/files/bin/whisper_wrapper
+++ b/files/bin/whisper_wrapper
@@ -9,8 +9,8 @@
 SUBMIT=false
 [[ "$1" == "--submit" ]] && SUBMIT=true
 
-STATE_FILE="/tmp/whisper_recording_state"
-MONITOR_PID_FILE="/tmp/whisper_monitor.pid"
+STATE_FILE="/tmp/whisper_recording_state_${USER}"
+MONITOR_PID_FILE="/tmp/whisper_monitor_${USER}.pid"
 CUE_DIR="$HOME/.local/share/whisper_cues"
 SW_DB="$HOME/Library/Application Support/ru.starmel.OpenSuperWhisper/recordings.sqlite"
 

--- a/files/cerico-w-user.zsh-theme
+++ b/files/cerico-w-user.zsh-theme
@@ -1,3 +1,8 @@
+_pdir="${PWD##*/}"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[blue]%}(%{$fg[red]%}"
+ZSH_THEME_GIT_PROMPT_DIRTY="%{$fg[blue]%}) %{$fg[yellow]%}✗ "
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[blue]%}) "
+
 _update_pdir() {
   if [[ "$PWD" == "$HOME/worktrees/"* ]]; then
     local rel="${PWD#$HOME/worktrees/}"

--- a/files/claude/hooks/update-tab-titles.ts
+++ b/files/claude/hooks/update-tab-titles.ts
@@ -5,7 +5,7 @@
 import { statSync, readFileSync, writeFileSync } from 'node:fs'
 
 const ASSISTANT_NAME = process.env.CLAUDE_NAME || 'Claude'
-const TAB_CACHE = '/tmp/iterm-tab-count'
+const TAB_CACHE = `/tmp/iterm-tab-count-${process.env.USER || 'default'}`
 const CACHE_TTL_MS = 30_000
 
 interface UserPromptPayload {

--- a/files/claude/skills/speak/speak.sh
+++ b/files/claude/skills/speak/speak.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 VOICE="${1:-af_sky}"
-TEXT="$(cat /tmp/claude_speak.txt)"
-[[ -z "$TEXT" ]] && echo "No text in /tmp/claude_speak.txt" && exit 1
+TEXT="$(cat /tmp/claude_speak_${USER}.txt)"
+[[ -z "$TEXT" ]] && echo "No text in /tmp/claude_speak_${USER}.txt" && exit 1
 curl -s -X POST http://127.0.0.1:8880/v1/audio/speech \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg text "$TEXT" --arg voice "$VOICE" '{model:"kokoro",input:$text,voice:$voice,response_format:"mp3"}')" \
-  -o /tmp/claude_speak.mp3 && afplay /tmp/claude_speak.mp3
+  -o /tmp/claude_speak_${USER}.mp3 && afplay /tmp/claude_speak_${USER}.mp3

--- a/files/claude/skills/ticket-check/SKILL.md
+++ b/files/claude/skills/ticket-check/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: ticket-check
+description: Grade ticket clarity and whether the branch actually fixes the issue described in the ticket.
+user-invocable: true
+argument: ticket ID (e.g. MIN-1916). If omitted, extract from branch name.
+---
+
+# Ticket Check
+
+Grade a ticket's clarity and whether the current branch's code changes actually fix the described issue.
+
+## Usage
+
+- `/ticket-check` - Auto-detect ticket from branch name
+- `/ticket-check MIN-1916` - Specify ticket explicitly
+
+## Step 1: Identify the Ticket
+
+If no ticket ID provided, extract from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Parse the ticket ID from common branch patterns:
+- `gareth/min-1916-slug` → `MIN-1916`
+- `gh-123-slug` → GitHub issue #123
+- `fix/PROJ-456-slug` → `PROJ-456`
+
+## Step 2: Fetch the Ticket
+
+Try sources in order until one succeeds:
+
+1. **Linear** — Use `mcp__claude_ai_Linear__get_issue` or `mcp__claude_ai_Linear__list_issues` with the ticket ID
+2. **GitHub** — `gh issue view <number>` if the ID is numeric or matches a GH issue
+3. **Branch name only** — If neither source has the ticket, use the branch name as the sole signal. Flag this as degraded confidence.
+
+Capture:
+- Title
+- Description / acceptance criteria
+- Priority / severity
+- Labels
+- Any linked issues or context
+
+## Step 3: Grade Ticket Clarity (A-F, /100)
+
+Evaluate the ticket on these dimensions:
+
+| Dimension | Weight | What to look for |
+|-----------|--------|------------------|
+| **Problem statement** | 25% | Is the user-facing problem clearly described? Can you understand what's broken without reading the code? |
+| **Reproduction path** | 20% | Steps to reproduce, affected users/scenarios, frequency |
+| **Acceptance criteria** | 25% | What does "fixed" look like? Are there measurable conditions? |
+| **Scope boundaries** | 15% | Is it clear what's in/out of scope? Could two engineers read this and build the same thing? |
+| **Context & evidence** | 15% | Links to logs, screenshots, error messages, related tickets |
+
+### Scoring guide
+
+- **A (90-100)**: Could hand to any engineer and they'd build the right thing
+- **B (80-89)**: Minor ambiguity but intent is clear
+- **C (70-79)**: Key details missing, requires assumptions
+- **D (60-69)**: Vague enough that different engineers would build different things
+- **F (<60)**: Title-only, no description, or actively misleading
+
+If ticket clarity is C or below, list the specific ambiguities that could lead to a wrong fix.
+
+## Step 4: Understand the Fix
+
+```bash
+git diff main...HEAD
+git diff --name-only main...HEAD
+git log --oneline main...HEAD
+```
+
+Read changed files. For each change, understand:
+- What code path is being modified
+- What trigger/condition activates this code
+- What user scenario would exercise this path
+
+## Step 5: Grade Solution Alignment (A-F, /100)
+
+Evaluate whether the code changes fix the problem described in the ticket:
+
+| Dimension | Weight | What to look for |
+|-----------|--------|------------------|
+| **Root cause match** | 35% | Does the fix address the actual root cause described in the ticket, or a symptom/adjacent issue? Trace the user scenario from the ticket through the code to verify. |
+| **Completeness** | 25% | Does the fix cover all scenarios implied by the ticket? Are there code paths where the same bug still exists? (Run a mental sibling audit against the ticket's scope, not just the diff's scope.) |
+| **No over-fix** | 15% | Does the fix stay within the ticket's scope, or does it fix things the ticket didn't ask for? (Over-fixing isn't always bad but should be flagged.) |
+| **Regression safety** | 15% | Could the fix break existing behaviour? Are there tests? |
+| **User experience** | 10% | From the user's perspective, would this fix resolve their reported issue? |
+
+### Scoring guide
+
+- **A (90-100)**: Fix directly addresses root cause, covers all paths, well-tested
+- **B (80-89)**: Fixes the issue but minor gaps (e.g. one edge case, missing test)
+- **C (70-79)**: Partially fixes the issue — some scenarios still broken
+- **D (60-69)**: Fixes a related but different problem than what the ticket describes
+- **F (<60)**: Fix doesn't address the ticket at all, or makes it worse
+
+### Root cause tracing
+
+This is the most important part. For each claim in the ticket:
+
+1. Identify the specific user action or system event
+2. Trace it through the code to find where it fails
+3. Check if the diff modifies that specific failure point
+4. If the diff modifies a *different* failure point, flag the mismatch
+
+## Output Format
+
+```
+## Ticket Check: [TICKET-ID]
+
+### Ticket
+**Title**: [title]
+**Source**: Linear / GitHub / branch name only
+**Description**: [1-2 sentence summary]
+
+### Ticket Clarity: [A-F] ([score]/100)
+[Brief justification per dimension. List ambiguities if C or below.]
+
+### Solution Alignment: [A-F] ([score]/100)
+
+**Root cause trace**:
+- Ticket describes: [what the user experiences]
+- Expected failure point: [where in the code this would fail]
+- Fix modifies: [what the diff actually changes]
+- Match: [yes/partial/no] — [explanation]
+
+**Coverage gaps**: [any scenarios from the ticket not addressed by the fix]
+**Over-fix**: [any changes beyond ticket scope]
+**Regression risk**: [low/medium/high — why]
+
+### Verdict
+[1-2 sentences: ship it / needs work / wrong fix]
+```

--- a/files/zsh/claude.zsh
+++ b/files/zsh/claude.zsh
@@ -78,7 +78,7 @@ _wez_layout() {
 
 _claude_wez() {
   local session="${${PWD##*/}//[.:]/_}"
-  local state_file="/tmp/wez_claude_${session}"
+  local state_file="/tmp/wez_claude_${USER}_${session}"
 
   if [[ -f "$state_file" ]]; then
     local saved_pane
@@ -173,7 +173,7 @@ vps() {
   [[ -z "$1" ]] && { sshs; return; }
   local host="$1" session="vps_${1//[.:]/_}"
   shift
-  local state_file="/tmp/wez_${session}"
+  local state_file="/tmp/wez_${USER}_${session}"
   if [[ -f "$state_file" ]]; then
     local saved_pane
     saved_pane=$(cat "$state_file")

--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -237,7 +237,7 @@ collapse () {
     wezterm cli kill-pane --pane-id "$pane" 2>/dev/null
   done
   local session="${${PWD##*/}//[.:]/_}"
-  rm -f "/tmp/wez_claude_${session}"
+  rm -f "/tmp/wez_claude_${USER}_${session}"
 }
 
 vsc () { # list or switch vscode themes # ➜ vsc sunlight


### PR DESCRIPTION
scope tmp file paths per user to avoid collisions
Add ticket-check skill for grading ticket clarity and solution alignment.
Fix zsh theme first-render showing oh-my-zsh default git prompt format
by initializing prompt variables before precmd hook.

Closes #601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated temporary file and lock directory paths to be user-specific across multiple shell scripts and utilities for improved environment isolation.

* **New Features**
  * Added ticket-check skill for evaluating ticket clarity across multiple criteria and assessing whether current branch changes address the described issue. Supports automatic ticket ID extraction from branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->