### PR TITLE
gh-605: desktop mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ group_vars/*
 !group_vars/all/
 group_vars/all/*
 !group_vars/all/example.yml
+host_vars/*/
+!host_vars/example.yml
 TODO.md
 TODO*.md
 sites/*yml

--- a/files/desktopmapping/DesktopMapping.swift
+++ b/files/desktopmapping/DesktopMapping.swift
@@ -1,0 +1,194 @@
+import Cocoa
+import ApplicationServices
+
+struct DesktopEntry {
+    let number: Int
+    let app: String
+    let sites: [String]
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    var statusItem: NSStatusItem!
+    var entries: [DesktopEntry] = []
+    var accessibilityGranted = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        checkAccessibility()
+        entries = loadConfig()
+        updateTitle()
+        buildMenu()
+
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(spaceChanged),
+            name: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc func spaceChanged() {
+        updateTitle()
+        buildMenu()
+    }
+
+    func checkAccessibility() {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        accessibilityGranted = AXIsProcessTrustedWithOptions(options)
+    }
+
+    func updateTitle() {
+        let num = currentSpaceIndex().map(String.init) ?? "?"
+        statusItem.button?.title = num
+    }
+
+    let spaceKeyCodes: [Int: UInt16] = [
+        1: 18, 2: 19, 3: 20, 4: 21, 5: 23, 6: 22, 7: 26, 8: 28,
+        9: 25, 10: 29, 11: 12, 12: 13, 13: 14, 14: 15, 15: 17, 16: 16
+    ]
+
+    @objc func switchToDesktop(_ sender: NSMenuItem) {
+        guard accessibilityGranted else {
+            checkAccessibility()
+            return
+        }
+        guard let keyCode = spaceKeyCodes[sender.tag] else { return }
+        let src = CGEventSource(stateID: .hidSystemState)
+        if let down = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true),
+           let up = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false) {
+            down.flags = .maskControl
+            up.flags = .maskControl
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+        }
+    }
+
+    func currentSpaceIndex() -> Int? {
+        guard let info = CGSCopyManagedDisplaySpaces(CGSMainConnectionID()) as? [[String: Any]] else {
+            return nil
+        }
+
+        for display in info {
+            guard let currentSpace = display["Current Space"] as? [String: Any],
+                  let currentID = currentSpace["ManagedSpaceID"] as? Int,
+                  let spaces = display["Spaces"] as? [[String: Any]] else { continue }
+
+            for (index, space) in spaces.enumerated() {
+                if let sid = space["ManagedSpaceID"] as? Int, sid == currentID {
+                    return index + 1
+                }
+            }
+        }
+        return nil
+    }
+
+    @objc func openAccessibility() {
+        checkAccessibility()
+        if !accessibilityGranted,
+           let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
+            NSWorkspace.shared.open(url)
+        }
+        buildMenu()
+    }
+
+    func buildMenu() {
+        let menu = NSMenu()
+        let current = currentSpaceIndex()
+
+        if !accessibilityGranted {
+            let warning = NSMenuItem(title: "⚠ Accessibility permission required", action: #selector(openAccessibility), keyEquivalent: "")
+            warning.target = self
+            menu.addItem(warning)
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        for entry in entries {
+            let prefix = entry.number == current ? "▶ " : "   "
+            let title = "\(prefix)\(entry.number). \(entry.app)"
+            let item = NSMenuItem(title: title, action: #selector(switchToDesktop(_:)), keyEquivalent: "")
+            item.target = self
+            item.tag = entry.number
+
+            if entry.number == current {
+                item.attributedTitle = NSAttributedString(
+                    string: title,
+                    attributes: [.font: NSFont.boldSystemFont(ofSize: 13)]
+                )
+            }
+
+            if !entry.sites.isEmpty {
+                let submenu = NSMenu()
+                for site in entry.sites {
+                    let siteItem = NSMenuItem(title: site, action: #selector(switchToDesktop(_:)), keyEquivalent: "")
+                    siteItem.tag = entry.number
+                    siteItem.target = self
+                    submenu.addItem(siteItem)
+                }
+                item.submenu = submenu
+            }
+
+            menu.addItem(item)
+        }
+
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
+
+        statusItem.menu = menu
+    }
+
+    func loadConfig() -> [DesktopEntry] {
+        let path = NSString(string: "~/.config/desktops.yml").expandingTildeInPath
+        guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return []
+        }
+
+        var results: [DesktopEntry] = []
+        var currentNumber: Int?
+        var currentApp: String?
+        var currentSites: [String] = []
+        var inSites = false
+
+        for line in content.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if line.hasPrefix("  ") && !line.hasPrefix("    ") && trimmed.hasSuffix(":") {
+                if let num = currentNumber, let app = currentApp {
+                    results.append(DesktopEntry(number: num, app: app, sites: currentSites))
+                }
+                let key = trimmed.dropLast()
+                currentNumber = Int(key)
+                currentApp = nil
+                currentSites = []
+                inSites = false
+            } else if trimmed.hasPrefix("app:") {
+                currentApp = trimmed.dropFirst(4).trimmingCharacters(in: .whitespaces).trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            } else if trimmed == "sites:" {
+                inSites = true
+            } else if trimmed.hasPrefix("cask:") {
+                // skip
+            } else if inSites && trimmed.hasPrefix("- ") {
+                currentSites.append(String(trimmed.dropFirst(2)))
+            } else if !trimmed.isEmpty && !trimmed.hasPrefix("-") {
+                inSites = false
+            }
+        }
+
+        if let num = currentNumber, let app = currentApp {
+            results.append(DesktopEntry(number: num, app: app, sites: currentSites))
+        }
+
+        return results.sorted { $0.number < $1.number }
+    }
+}
+
+@_silgen_name("CGSCopyManagedDisplaySpaces")
+func CGSCopyManagedDisplaySpaces(_ conn: Int32) -> CFArray?
+
+@_silgen_name("CGSMainConnectionID")
+func CGSMainConnectionID() -> Int32
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/host_vars/example.yml
+++ b/host_vars/example.yml
@@ -1,1 +1,19 @@
 ansible_connection: local
+iterm_theme: "coffee"
+zsh_theme: "cerico-w-user"
+
+# Per-user desktop mappings live in separate files:
+# host_vars/<hostname>.localhost/<username>.yml
+#
+# These are loaded automatically if they match macbook_user.
+#
+# desktop_mapping:
+#   1:
+#     app: Slack
+#     bundle_id: com.tinyspeck.slackmacgap
+#   2:
+#     app: Vivaldi
+#     bundle_id: com.vivaldi.Vivaldi
+#     sites:
+#       - GitHub
+#       - Vercel

--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Check for per-user vars
+  ansible.builtin.stat:
+    path: "{{ [playbook_dir, 'host_vars', inventory_hostname, macbook_user.stdout + '.yml'] | path_join }}"
+  register: per_user_vars
+
+- name: Load per-user vars
+  ansible.builtin.include_vars:
+    file: "{{ per_user_vars.stat.path }}"
+  when: per_user_vars.stat.exists
+
 - name: Create wallpapers directory.
   file:
     path: "{{ ['~' + macbook_user.stdout, 'wallpapers'] | path_join }}"
@@ -143,6 +153,20 @@
     - Reminders
     - App Store
     - System Preferences
+
+- name: Derive desktop_app_bindings from desktop_mapping (single)
+  set_fact:
+    desktop_app_bindings: "{{ desktop_app_bindings | default([]) + [{'bundle_id': item.value.bundle_id, 'desktop': item.key | int}] }}"
+  loop: "{{ desktop_mapping | dict2items }}"
+  when: desktop_mapping is defined and item.value.bundle_id is defined and item.value.bundle_ids is not defined
+
+- name: Derive desktop_app_bindings from desktop_mapping (multi)
+  set_fact:
+    desktop_app_bindings: "{{ desktop_app_bindings | default([]) + [{'bundle_id': item.1, 'desktop': item.0.key | int}] }}"
+  with_subelements:
+    - "{{ (desktop_mapping | default({}) | dict2items | selectattr('value.bundle_ids', 'defined') | list) }}"
+    - value.bundle_ids
+  when: desktop_mapping is defined
 
 - name: Get space UUIDs for app bindings
   script: files/get_space_uuids.swift

--- a/roles/install/tasks/darwin.yml
+++ b/roles/install/tasks/darwin.yml
@@ -128,6 +128,9 @@
     - "wezterm"
     - "zed"
     - "zen"
+    - "notion"
+    - "proton-mail"
+    - "macdown"
 
 - name: Copy zshenv
   copy:

--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -1,4 +1,14 @@
 ---
+- name: Check for per-user vars
+  ansible.builtin.stat:
+    path: "{{ [playbook_dir, 'host_vars', inventory_hostname, macbook_user.stdout + '.yml'] | path_join }}"
+  register: per_user_vars
+
+- name: Load per-user vars
+  ansible.builtin.include_vars:
+    file: "{{ per_user_vars.stat.path }}"
+  when: per_user_vars.stat.exists
+
 - name: Copy WezTerm config
   ansible.builtin.copy:
     src: wezterm.lua
@@ -48,41 +58,98 @@
     state: directory
     mode: "0755"
 
-- name: Compile SpaceNumber menu bar app
+- name: Unload SpaceNumber LaunchAgent
   ansible.builtin.shell: >
-    swiftc -framework Cocoa
-    {{ playbook_dir }}/files/spacenumber/SpaceNumber.swift
-    -o /Users/{{ macbook_user.stdout }}/.local/bin/SpaceNumber
-  args:
-    creates: "/Users/{{ macbook_user.stdout }}/.local/bin/SpaceNumber"
-
-- name: Install SpaceNumber LaunchAgent
-  ansible.builtin.copy:
-    dest: "{{ ['~' + macbook_user.stdout, 'Library', 'LaunchAgents', 'com.macfair.spacenumber.plist'] | path_join }}"
-    mode: "0644"
-    content: |
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>com.macfair.spacenumber</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>/Users/{{ macbook_user.stdout }}/.local/bin/SpaceNumber</string>
-        </array>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-      </dict>
-      </plist>
-
-- name: Load SpaceNumber LaunchAgent
-  ansible.builtin.shell: >
-    launchctl bootout gui/$(id -u) /Users/{{ macbook_user.stdout }}/Library/LaunchAgents/com.macfair.spacenumber.plist 2>/dev/null;
-    launchctl bootstrap gui/$(id -u) /Users/{{ macbook_user.stdout }}/Library/LaunchAgents/com.macfair.spacenumber.plist
+    launchctl bootout gui/$(id -u) /Users/{{ macbook_user.stdout }}/Library/LaunchAgents/com.macfair.spacenumber.plist 2>/dev/null
   changed_when: false
+  failed_when: false
+
+- name: Remove SpaceNumber LaunchAgent
+  ansible.builtin.file:
+    path: "{{ ['~' + macbook_user.stdout, 'Library', 'LaunchAgents', 'com.macfair.spacenumber.plist'] | path_join }}"
+    state: absent
+
+- name: Remove SpaceNumber binary
+  ansible.builtin.file:
+    path: "/Users/{{ macbook_user.stdout }}/.local/bin/SpaceNumber"
+    state: absent
+
+- name: Manage DesktopMapping
+  when: desktop_mapping is defined
+  block:
+    - name: Create .config directory
+      ansible.builtin.file:
+        path: "{{ ['~' + macbook_user.stdout, '.config'] | path_join }}"
+        state: directory
+        mode: "0755"
+
+    - name: Deploy desktops.yml
+      ansible.builtin.template:
+        src: desktops.yml.j2
+        dest: "{{ ['~' + macbook_user.stdout, '.config', 'desktops.yml'] | path_join }}"
+
+    - name: Create DesktopMapping app bundle
+      ansible.builtin.file:
+        path: "/Users/{{ macbook_user.stdout }}/.local/bin/DesktopMapping.app/Contents/MacOS"
+        state: directory
+        mode: "0755"
+
+    - name: Compile DesktopMapping menu bar app
+      ansible.builtin.shell: >
+        swiftc -framework Cocoa
+        {{ playbook_dir }}/files/desktopmapping/DesktopMapping.swift
+        -o /Users/{{ macbook_user.stdout }}/.local/bin/DesktopMapping.app/Contents/MacOS/DesktopMapping
+      changed_when: true
+
+    - name: Install DesktopMapping Info.plist
+      ansible.builtin.copy:
+        dest: "/Users/{{ macbook_user.stdout }}/.local/bin/DesktopMapping.app/Contents/Info.plist"
+        mode: "0644"
+        content: |
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.macfair.desktopmapping</string>
+            <key>CFBundleName</key>
+            <string>DesktopMapping</string>
+            <key>CFBundleExecutable</key>
+            <string>DesktopMapping</string>
+            <key>LSUIElement</key>
+            <true/>
+          </dict>
+          </plist>
+
+    - name: Install DesktopMapping LaunchAgent
+      ansible.builtin.copy:
+        dest: "{{ ['~' + macbook_user.stdout, 'Library', 'LaunchAgents', 'com.macfair.desktopmapping.plist'] | path_join }}"
+        mode: "0644"
+        content: |
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>Label</key>
+            <string>com.macfair.desktopmapping</string>
+            <key>ProgramArguments</key>
+            <array>
+              <string>/usr/bin/open</string>
+              <string>-W</string>
+              <string>/Users/{{ macbook_user.stdout }}/.local/bin/DesktopMapping.app</string>
+            </array>
+            <key>RunAtLoad</key>
+            <true/>
+            <key>KeepAlive</key>
+            <true/>
+          </dict>
+          </plist>
+
+    - name: Load DesktopMapping LaunchAgent
+      ansible.builtin.shell: >
+        launchctl bootout gui/$(id -u) /Users/{{ macbook_user.stdout }}/Library/LaunchAgents/com.macfair.desktopmapping.plist 2>/dev/null;
+        launchctl bootstrap gui/$(id -u) /Users/{{ macbook_user.stdout }}/Library/LaunchAgents/com.macfair.desktopmapping.plist
+      changed_when: false
 
 - name: Create pnpm-audit directory
   file:

--- a/templates/desktops.yml.j2
+++ b/templates/desktops.yml.j2
@@ -1,0 +1,11 @@
+desktops:
+{% for num, entry in desktop_mapping | dictsort %}
+  {{ num }}:
+    app: {{ entry.app }}
+{% if entry.sites is defined %}
+    sites:
+{% for site in entry.sites %}
+      - {{ site }}
+{% endfor %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
add desktop mapping system with menu bar app
- Add DesktopMapping Swift menu bar app with click-to-switch and site submenus
- Add per-user desktop_mapping var with bundle_id/bundle_ids and sites support
- Template desktops.yml to ~/.config/ from host_vars for per-user configs
- Derive desktop_app_bindings from desktop_mapping in desktop role
- Add per-user vars loading via stat check in desktop and terminal roles
- Remove creates: guard on Swift compile tasks so source changes trigger rebuild
- Add notion, proton-mail, macdown to brew cask list
- Gitignore host_vars subdirectories for per-machine configs
- Update example.yml with desktop_mapping reference

Closes #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS status‑bar app to switch between configured desktops and sites; highlights the current Space and prompts for Accessibility if needed.

* **Documentation**
  * Expanded example host‑vars with terminal theme settings and commented desktop‑mapping usage.
  * New template to render per‑user desktop mappings.

* **Chores**
  * Added Notion, Proton Mail, and MacDown to install list.
  * Updated ignore rules to keep example host‑vars tracked.
  * Deployment now supports loading per‑user variables and installing the desktop‑mapping app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->