### PR TITLE
gh-607: desktopmapping loses accessibility permission after recompilation

### DIFF
--- a/files/claude/skills/issue/SKILL.md
+++ b/files/claude/skills/issue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: issue
+description: Create a GitHub issue for the current repo and report the number. Does not create a branch — user runs gbr manually when ready.
+user-invocable: true
+argument: optional description of the issue
+---
+
+# Issue
+
+Create a GitHub issue and report the number. Do NOT create a branch or switch context.
+
+## Instructions
+
+1. If the user provided a description, use it. Otherwise ask what the issue is about.
+
+2. Draft a concise title and body. The body should include:
+   - What the problem or feature is
+   - Why it matters (if known)
+   - Suggested fix or approach (if known)
+
+3. Create the issue:
+
+```bash
+gh issue create --title "<title>" --body "<body>"
+```
+
+4. Report the issue number and URL. Remind the user they can run `gbr <number>` when ready to start work.
+
+## Rules
+
+- Do NOT create a branch
+- Do NOT switch away from the current branch
+- Do NOT run `gbr`
+- The user decides when and how to start work (branch vs worktree)

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -807,6 +807,7 @@ _time_ago() {
 
 alias wtl=worktrees
 worktrees() { # List worktrees sorted by recency # ➜ worktrees | worktrees 2
+  setopt local_options nullglob
   local idx="${1:-}"
   local worktrees_dir=~/worktrees
   [[ ! -d "$worktrees_dir" ]] && { echo "No worktrees"; return }

--- a/roles/terminal/tasks/darwin.yml
+++ b/roles/terminal/tasks/darwin.yml
@@ -121,6 +121,12 @@
           </dict>
           </plist>
 
+    - name: Codesign DesktopMapping bundle
+      ansible.builtin.shell: >
+        codesign -f -s -
+        /Users/{{ macbook_user.stdout }}/.local/bin/DesktopMapping.app
+      changed_when: true
+
     - name: Install DesktopMapping LaunchAgent
       ansible.builtin.copy:
         dest: "{{ ['~' + macbook_user.stdout, 'Library', 'LaunchAgents', 'com.macfair.desktopmapping.plist'] | path_join }}"


### PR DESCRIPTION
codesign DesktopMapping and add /issue skill
- Ad-hoc codesign binary after compilation to preserve Accessibility grants across recompiles
- Add /issue skill for creating GH issues without auto-branching

Closes #607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-invocable issue creation workflow that prompts for details (if needed), drafts and files GitHub issues, and returns the issue number and URL; it will not create branches or switch context automatically.

* **Improvements**
  * Enabled code signing for the macOS desktop application binary.
  * Improved shell worktree handling to avoid glob-related errors when paths are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->