### PR TITLE
sentry mcp

### DIFF
--- a/files/cerico-w-user.zsh-theme
+++ b/files/cerico-w-user.zsh-theme
@@ -19,6 +19,6 @@ _update_pdir() {
 }
 add-zsh-hook precmd _update_pdir
 
-PROMPT='%{$fg_bold[cyan]%}☁ $USER@%m%{$reset_color%}:%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})${_pdir} ➜%{$reset_color%} $(git_prompt_info)'
+PROMPT='%{$fg_bold[cyan]%}☁ $USER@%m%{$reset_color%}:%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})${_pdir} ➜%{$reset_color%} $(_short_git_prompt_info)'
 
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"

--- a/files/cerico.zsh-theme
+++ b/files/cerico.zsh-theme
@@ -14,6 +14,6 @@ _update_pdir() {
 }
 add-zsh-hook precmd _update_pdir
 
-PROMPT='%{$fg_bold[cyan]%}☁ %m%{$reset_color%}:%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})${_pdir} ➜%{$reset_color%} $(git_prompt_info)'
+PROMPT='%{$fg_bold[cyan]%}☁ %m%{$reset_color%}:%(?:%{$fg_bold[green]%}:%{$fg_bold[red]%})${_pdir} ➜%{$reset_color%} $(_short_git_prompt_info)'
 
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%}"

--- a/files/zsh/git.zsh
+++ b/files/zsh/git.zsh
@@ -3,6 +3,22 @@ unalias gpf 2>/dev/null
 
 _is_git_repo() { git rev-parse --is-inside-work-tree &>/dev/null; }
 
+_short_branch() {
+  local branch=$1
+  [[ "$branch" =~ (^|[/-])([a-zA-Z]{3})-([0-9]+) ]] && { echo "${match[2]:u}-${match[3]}"; return }
+  [[ "$branch" =~ (^|[/-])gh-([0-9]+) ]] && { echo "GH-${match[2]}"; return }
+  echo "$branch"
+}
+
+_short_git_prompt_info() {
+  local branch
+  branch=$(git symbolic-ref --short HEAD 2>/dev/null) || { git_prompt_info; return }
+  local short=$(_short_branch "$branch")
+  local info=$(git_prompt_info)
+  [[ -z "$info" ]] && return
+  echo "${info/$branch/$short}"
+}
+
 _repo_root() {
   local common_dir
   common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
@@ -446,13 +462,7 @@ delete_old_branches () {
     [[ "$is_merged" != true ]] && continue
 
     local wt_path=~/worktrees/"$repo"/"${branch//\//-}"
-    if [[ -d "$wt_path" ]]; then
-      echo "Removing worktree for $merge_type branch $branch"
-      if ! git worktree remove "$wt_path" 2>/dev/null && ! git worktree remove --force "$wt_path"; then
-        echo "Warning: Failed to remove worktree at $wt_path — skipping branch $branch"
-        continue
-      fi
-    fi
+    [[ -d "$wt_path" ]] && { echo "Skipping $merge_type branch $branch — has active worktree"; continue }
     echo "Deleting $merge_type branch $branch"
     [[ "$merge_type" == "merged" ]] && git branch -d "$branch" || git branch -D "$branch"
   done

--- a/files/zsh/gsd.zsh
+++ b/files/zsh/gsd.zsh
@@ -214,7 +214,11 @@ gsds() {
 }
 
 resume() {
-  [[ -f ".planning/STATE.md" ]] && claude "/gsd:resume-work" || claude
+  if [[ -f ".planning/STATE.md" ]]; then
+    claude "/gsd-resume-work"
+  else
+    claude
+  fi
 }
 
 gsd() {
@@ -233,19 +237,19 @@ Commands:
   info            Show info for current project (or just run 'info')
   register [name] Register current dir as GSD project
   rm              Remove current dir from registry
-  new             Start new project (/gsd:new-project)
-  milestone [n]   Start new milestone (/gsd:new-milestone [name])
-  map [area]      Map existing codebase (/gsd:map-codebase [area])
-  discuss [N]     Discuss a phase (/gsd:discuss-phase N)
-  plan [N]        Plan a phase (/gsd:plan-phase N)
-  exec [N]        Execute a phase (/gsd:execute-phase N)
-  verify [N]      Verify work (/gsd:verify-work N)
-  resume          Resume work (/gsd:resume-work)
-  pause           Pause work (/gsd:pause-work)
-  progress        Check progress (/gsd:progress)
-  add [desc]      Add a todo (/gsd:add-todo [desc])
-  todos           Check todos (/gsd:check-todos)
-  debug [desc]    Debug an issue (/gsd:debug [desc])
+  new             Start new project (/gsd-new-project)
+  milestone [n]   Start new milestone (/gsd-new-milestone [name])
+  map [area]      Map existing codebase (/gsd-map-codebase [area])
+  discuss [N]     Discuss a phase (/gsd-discuss-phase N)
+  plan [N]        Plan a phase (/gsd-plan-phase N)
+  exec [N]        Execute a phase (/gsd-execute-phase N)
+  verify [N]      Verify work (/gsd-verify-work N)
+  resume          Resume work (/gsd-resume-work)
+  pause           Pause work (/gsd-pause-work)
+  progress        Check progress (/gsd-progress)
+  add [desc]      Add a todo (/gsd-add-todo [desc])
+  todos           Check todos (/gsd-check-todos)
+  debug [desc]    Debug an issue (/gsd-debug [desc])
 EOF
       ;;
 
@@ -266,55 +270,55 @@ EOF
       ;;
 
     new)
-      claude "/gsd:new-project"
+      claude "/gsd-new-project"
       ;;
 
     milestone)
-      claude "/gsd:new-milestone $*"
+      claude "/gsd-new-milestone $*"
       ;;
 
     map)
-      claude "/gsd:map-codebase $*"
+      claude "/gsd-map-codebase $*"
       ;;
 
     discuss)
-      claude "/gsd:discuss-phase $*"
+      claude "/gsd-discuss-phase $*"
       ;;
 
     plan)
-      claude "/gsd:plan-phase $*"
+      claude "/gsd-plan-phase $*"
       ;;
 
     exec|execute)
-      claude "/gsd:execute-phase $*"
+      claude "/gsd-execute-phase $*"
       ;;
 
     verify)
-      claude "/gsd:verify-work $*"
+      claude "/gsd-verify-work $*"
       ;;
 
     resume)
-      claude "/gsd:resume-work"
+      claude "/gsd-resume-work"
       ;;
 
     pause)
-      claude "/gsd:pause-work"
+      claude "/gsd-pause-work"
       ;;
 
     progress|status)
-      claude "/gsd:progress"
+      claude "/gsd-progress"
       ;;
 
     add)
-      claude "/gsd:add-todo $*"
+      claude "/gsd-add-todo $*"
       ;;
 
     todos)
-      claude "/gsd:check-todos"
+      claude "/gsd-check-todos"
       ;;
 
     debug)
-      claude "/gsd:debug $*"
+      claude "/gsd-debug $*"
       ;;
 
     *)


### PR DESCRIPTION
shorten Linear/GH branch names in zsh prompt and preserve worktrees
- Shorten Linear ticket branches (MIN-1941, EGG-42) and GH issue branches (GH-123) in zsh prompt
- Extract _short_branch and _short_git_prompt_info to git.zsh, shared by both themes
- Skip branches with active worktrees in delete_old_branches instead of removing them
- Fix gsd command help text and routing to use /gsd-* instead of /gsd:*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Command prompts now show shortened Git branch names for clearer, more compact display.
  * Worktree cleanup will safely skip directories that have active worktrees instead of attempting forced removals.
  * GSD workflow commands use dash-delimited action strings (e.g., /gsd-resume-work), and resume behavior more reliably targets the appropriate workflow state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->