### PR TITLE
lcopen current

### DIFF
--- a/files/zsh/main.zsh
+++ b/files/zsh/main.zsh
@@ -223,9 +223,19 @@ sw () {
     osascript -e "tell application \"System Events\" to key code ${SPACE_KEY_CODES[$idx]} using {control down}"
 }
 
-lcopen () { # Open Linear ticket in app # ➜ lcopen 226 | lcopen EGG-226
-  [[ -z "$1" ]] && { echo "Usage: lcopen <number|TEAM-number>"; return 1; }
+lcopen () { # Open Linear ticket in app # ➜ lcopen | lcopen 226 | lcopen EGG-226
   local id=$1
+  if [[ -z "$id" ]]; then
+    local branch=$(git branch --show-current 2>/dev/null)
+    [[ -z "$branch" ]] && { echo "Not in a git repo"; return 1; }
+    if [[ "$branch" =~ (^|[-/])(min|MIN)-([0-9]+) ]]; then
+      id="MIN-${match[3]}"
+    elif [[ "$branch" =~ (^|[-/])([A-Za-z]{2,5})-([0-9]+) ]] && [[ "${match[2]:l}" != "gh" && "${match[2]:l}" != "cl" ]]; then
+      id="${match[2]:u}-${match[3]}"
+    else
+      echo "Can't extract ticket from branch: $branch"; return 1
+    fi
+  fi
   [[ "$id" =~ ^[0-9]+$ ]] && id="MIN-$id"
   open "linear://issue/${id:u}"
 }


### PR DESCRIPTION
extract Linear ticket from branch name in lcopen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `lcopen` command now automatically extracts Linear issue identifiers from your current git branch name when called without arguments, supporting common branch naming patterns. Manual ticket specification remains available for flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->